### PR TITLE
Renamed --file to --playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ SimploTask (aka `spot`) is a powerful and easy-to-use tool for effortless deploy
 
 SimploTask supports the following command-line options:
 
-- `-p`, `--file=`: Specifies the playbook file to be used. Defaults to `spot.yml`. You can also set the environment
-  variable `$SPOT_FILE` to define the playbook file path.
+- `-p`, `--playbook=`: Specifies the playbook file to be used. Defaults to `spot.yml`. You can also set the environment
+  variable `$SPOT_PLAYBOOK` to define the playbook file path.
 - `-t`, `--task=`: Specifies the task name to execute. The task should be defined in the playbook file.
   If not specified all the tasks will be executed.
 - `-d`, `--target=`: Specifies the target name to use for the task execution. The target should be defined in the playbook file and can represent remote hosts, inventory files, or inventory URLs. If not specified the `default` target will be used. User can pass a host name or IP instead of the target name for a quick override. Providing the `-d`, `--target` flag multiple times with different targets sets multiple destination targets or multiple hosts, e.g., `-d prod -d dev` or `-d example1.com -d example2.com`.

--- a/app/main.go
+++ b/app/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 type options struct {
-	PlaybookFile string        `short:"p" long:"file" env:"SPOT_FILE" description:"playbook file" default:"spot.yml"`
+	PlaybookFile string        `short:"p" long:"playbook" env:"SPOT_PLAYBOOK" description:"playbook file" default:"spot.yml"`
 	TaskName     string        `short:"t" long:"task" description:"task name"`
 	Targets      []string      `short:"d" long:"target" description:"target name" default:"default"`
 	Concurrent   int           `short:"c" long:"concurrent" description:"concurrent tasks" default:"1"`

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -25,7 +25,7 @@ func Test_main(t *testing.T) {
 	hostAndPort, teardown := startTestContainer(t)
 	defer teardown()
 
-	args := []string{"simplotask", "--dbg", "--file=runner/testdata/conf-local.yml", "--user=test", "--key=runner/testdata/test_ssh_key", "--target=" + hostAndPort}
+	args := []string{"simplotask", "--dbg", "--playbook=runner/testdata/conf-local.yml", "--user=test", "--key=runner/testdata/test_ssh_key", "--target=" + hostAndPort}
 	os.Args = args
 	main()
 }


### PR DESCRIPTION
This is a matter of taste, but I think that this change makes the project a bit better.

Here is the currect interface of spot:

```
$ spot_0_7_2 --help
simplotask v0.7.2-7ad5d3d-2023-05-01T08:54:45Z
Usage:
  spot_0_7_2

Application Options:
  -p, --file=           playbook file (default: spot.yml) [$SPOT_FILE]
...
      --inventory-file= inventory file [$SPOT_INVENTORY]
...
```

Here I did the changes

 * `--file` => `--playbook`. This make long option `playbook` consistent with the short option `p`
 * `$SPOT_FILE` => `$SPOT_PLAYBOOK`. This makes it play well with the other env variable `$SPOT_INVENTORY`