### PR TITLE
add support of tags in inventory or hosts and match as destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Targets contains environments each of which represents a set of hosts, for examp
 ```yaml
 targets:
   prod:
-    hosts: [{host: "h1.example.com", user: "test"}, {"h2.example.com", "port": 2222}]
+    hosts: [{host: "h1.example.com", user: "test"}, {"h2.example.com", "port": 2222, name: "h2"}]
   staging:
     groups: ["staging"]
   dev:
@@ -237,6 +237,19 @@ There are several ways to override or alter the target defined in the playbook f
 - `--user` set the ssh user to run the playbook on remote hosts. Example: `--user=test`.
 - `--key` set the ssh key to run the playbook on remote hosts. Example: `--key=/path/to/key`.
 
+### Target selection
+
+The target selection is done in the following order:
+
+- if `--target` is set, it will be used.
+  - first Spot will try to match on target name in the playbook file.
+  - if no match found, Spot will try to match on group name in the inventory file.
+  - if no match found, Spot will try to match on tags in the inventory file.
+  - if no match found, Spot will try to match on host name in the inventory file.
+  - if no match found, Spot will try to match on host address in the playbook file.
+  - if no match found, Spot will use it as a host name.
+- if `--target` is not set, Spot will assume the `default` target.
+
 ### Inventory 
 
 The inventory file is a simple yml what can represent a list of hosts or a list of groups with hosts. In case if both groups and hosts defined, the hosts will be merged with groups and will add a new group named `hosts`.
@@ -248,7 +261,7 @@ This is an example of the inventory file with groups
 ```yaml
 groups:
   dev:
-    - {host: "h1.example.com", name: "h1"}
+    - {host: "h1.example.com", name: "h1", tags:["us-east1", "vpc-1234567"]}
     - {host: "h2.example.com", port: 2233, name: "h2"}
     - {host: "h3.example.com", user: "user1"}
     - {host: "h4.example.com", user: "user2", name: "h4"}
@@ -257,9 +270,13 @@ groups:
     - {host: "h6.example.com", user: "user3", name: "h6"}
 ```
 
-In case if port not defined, the default port 22 will be used. If user not defined, the playbook's user will be used. 
+- host: the host name or IP address of the remote host.
+- port: the ssh port of the remote host. Optional, default is 22.
+- user: the ssh user of the remote host. Optional, default is the user defined in the playbook file or `--user` flag.
+- name: the name of the remote host. Optional.
+- tags: the list of tags of the remote host. Optional.
 
-note: the `name` field is optional and used only to make reports/log more readable.
+In case if port not defined, the default port 22 will be used. If user not defined, the playbook's user will be used. 
 
 This is an example of the inventory file with hosts only (no groups)
 
@@ -267,7 +284,7 @@ This is an example of the inventory file with hosts only (no groups)
 hosts:
   - {host: "hh1.example.com", name: "hh1"}
   - {host: "hh2.example.com", port: 2233, name: "hh2", user: "user1"}
-  - {host: "h2.example.com", port: 2233, name: "h2"}
+  - {host: "h2.example.com", port: 2233, name: "h2", tags:["us-east1", "vpc-1234567"]}
   - {host: "h3.example.com", user: "user1", name: "h3"}
   - {host: "h4.example.com", user: "user2", name: "h4"}
 ```

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -63,10 +63,11 @@ type Cmd struct {
 
 // Destination defines destination info
 type Destination struct {
-	Name string `yaml:"name"`
-	Host string `yaml:"host"`
-	Port int    `yaml:"port"`
-	User string `yaml:"user"`
+	Name string   `yaml:"name"`
+	Host string   `yaml:"host"`
+	Port int      `yaml:"port"`
+	User string   `yaml:"user"`
+	Tags []string `yaml:"tags"`
 }
 
 // CopyInternal defines copy command, implemented internally
@@ -282,6 +283,20 @@ func (p *PlayBook) TargetHosts(name string) ([]Destination, error) {
 			res[i] = r
 		}
 		return res, nil
+	}
+
+	// try as a tag in inventory
+	for _, h := range p.inventory.Groups["all"] {
+		if len(h.Tags) == 0 {
+			continue
+		}
+		for _, t := range h.Tags {
+			if strings.EqualFold(t, name) {
+				res := []Destination{h}
+				res[0].User = userOverride(h.User)
+				return res, nil
+			}
+		}
 	}
 
 	// try as single host name in inventory

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -333,14 +333,14 @@ func TestTargetHosts(t *testing.T) {
 				"all": {
 					{Host: "host1.example.com", Port: 22, User: "user1"},
 					{Host: "host2.example.com", Port: 22, User: "defaultuser", Name: "host2"},
-					{Host: "host3.example.com", Port: 22, User: "defaultuser", Name: "host3"},
+					{Host: "host3.example.com", Port: 22, User: "defaultuser", Name: "host3", Tags: []string{"tag1", "tag2"}},
 				},
 				"group1": {
 					{Host: "host2.example.com", Port: 2222, User: "defaultuser", Name: "host2"},
 				},
 			},
 			Hosts: []Destination{
-				{Host: "host3.example.com", Port: 22, Name: "host3"},
+				{Host: "host3.example.com", Port: 22, Name: "host3", Tags: []string{"tag1", "tag2"}},
 			},
 		},
 	}
@@ -368,13 +368,18 @@ func TestTargetHosts(t *testing.T) {
 			false,
 		},
 		{
+			"target as a tag from inventory", "tag2", nil,
+			[]Destination{{Host: "host3.example.com", Port: 22, User: "defaultuser", Name: "host3", Tags: []string{"tag1", "tag2"}}},
+			false,
+		},
+		{
 			"target as single host by name from inventory", "host3", nil,
-			[]Destination{{Host: "host3.example.com", Port: 22, User: "defaultuser", Name: "host3"}},
+			[]Destination{{Host: "host3.example.com", Port: 22, User: "defaultuser", Name: "host3", Tags: []string{"tag1", "tag2"}}},
 			false,
 		},
 		{
 			"target as single host from inventory", "host3.example.com", nil,
-			[]Destination{{Host: "host3.example.com", Port: 22, User: "defaultuser", Name: "host3"}},
+			[]Destination{{Host: "host3.example.com", Port: 22, User: "defaultuser", Name: "host3", Tags: []string{"tag1", "tag2"}}},
 			false,
 		},
 		{
@@ -394,7 +399,7 @@ func TestTargetHosts(t *testing.T) {
 		},
 		{
 			"user override", "host3", &Overrides{User: "overriddenuser"},
-			[]Destination{{Host: "host3.example.com", Port: 22, User: "overriddenuser", Name: "host3"}},
+			[]Destination{{Host: "host3.example.com", Port: 22, User: "overriddenuser", Name: "host3", Tags: []string{"tag1", "tag2"}}},
 			false,
 		},
 	}


### PR DESCRIPTION
the idea from [this discussion](https://github.com/umputun/spot/discussions/31#discussioncomment-5774743) by @bessarabov

It adds tags to all places with `[]Destination` i.e. the list of hosts or inventory and matches `--target` by tag, in addition to all the other matches. I have added a section to [README.md](https://github.com/umputun/spot#target-selection] explaining the matching order