### PR TITLE
add names type of targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,11 @@ Targets are used to define the remote hosts to execute the tasks on. Targets can
 
 - `hosts`: a list of destination host names or IP addresses, with optional port and username, to execute the tasks on. Example: `hosts: [{host: "h1.example.com", user: "test", name: "h1}, {host: "h2.example.com", "port": 2222}]`. If no user is specified, the user defined in the top section of the playbook file (or override) will be used. If no port is specified, port 22 will be used.
 - `groups`: a list of groups from inventory to use. Example: `groups: ["dev", "staging"}`. Special group `all` combines all the groups. The [inventory file](#inventory-file-format) contains a list of hosts and groups with hosts.
+- `names`: a list of names of hosts from inventory to use. Example: `names: ["h1", "h2"]`.
 
+All the target types can be combined, i.e. `hosts` and `groups` and `hosts` and `names` all can be used together in the same target. To avoid possible duplicates of the hosts, the final list of hosts is deduplicated by the host+ip+user. 
 
-Targets contains environments each of which represents a set of hosts, for example:
+example of targets in the playbook file:
 
 ```yaml
 targets:
@@ -224,6 +226,7 @@ targets:
     groups: ["staging"]
   dev:
     groups: ["dev", "staging"]
+    names: ["host1", "host2"]
   all-servers:
     groups: ["all"]
 ```

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -321,7 +321,6 @@ func TestCmd_getScriptFile(t *testing.T) {
 }
 
 func TestTargetHosts(t *testing.T) {
-
 	p := &PlayBook{
 		User: "defaultuser",
 		Targets: map[string]Target{
@@ -330,6 +329,7 @@ func TestTargetHosts(t *testing.T) {
 			"target3": {Name: "target3", Groups: []string{"group1"},
 				Hosts: []Destination{{Host: "host4.example.com", Port: 22, Name: "host4", Tags: []string{"tag4"}, User: "user4"}},
 			},
+			"target4": {Name: "target4", Groups: []string{"group1"}, Names: []string{"host3"}},
 		},
 		inventory: &InventoryData{
 			Groups: map[string][]Destination{
@@ -371,6 +371,13 @@ func TestTargetHosts(t *testing.T) {
 			[]Destination{
 				{Name: "host4", Host: "host4.example.com", Port: 22, User: "user4", Tags: []string{"tag4"}},
 				{Host: "host2.example.com", Port: 2222, User: "defaultuser", Name: "host2", Tags: []string{"tag1"}}},
+			false,
+		},
+		{
+			"target with both group and name", "target4", nil,
+			[]Destination{
+				{Name: "host3", Host: "host3.example.com", Port: 22, User: "defaultuser", Tags: []string{"tag1", "tag2"}},
+				{Name: "host2", Host: "host2.example.com", Port: 2222, User: "defaultuser", Tags: []string{"tag1"}}},
 			false,
 		},
 		{


### PR DESCRIPTION
As proposed  by @bessarabov in https://github.com/umputun/spot/discussions/31, I have added "names" type to targets, i.e.

```
targets:
  prod:
     names: ["h1", "h2"]
```

This will match to names of hosts, i.e. `name` field from the inventory