### PR TITLE
Added info about env SPOT_INVENTORY to --help

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -35,7 +35,7 @@ type options struct {
 	SSHTimeout   time.Duration `long:"timeout" description:"ssh timeout" default:"30s"`
 
 	// overrides
-	Inventory string            `short:"i" long:"inventory" description:"inventory file or url"`
+	Inventory string            `short:"i" long:"inventory" description:"inventory file or url [$SPOT_INVENTORY]"`
 	SSHUser   string            `short:"u" long:"user" description:"ssh user"`
 	SSHKey    string            `short:"k" long:"key" description:"ssh key"`
 	Env       map[string]string `short:"e" long:"env" description:"environment variables for all commands"`


### PR DESCRIPTION
Tiny addition to `--help`. Now there is no info about env variable in `--help`:

```
$ spot --help
spot v0.9.1-0aa555f-2023-05-02T08:06:47Z
Usage:
  spot [command]

Application Options:
  -p, --file=       playbook file (default: spot.yml) [$SPOT_FILE]
  -t, --task=       task name
  -d, --target=     target name (default: default)
  -c, --concurrent= concurrent tasks (default: 1)
      --timeout=    ssh timeout (default: 30s)
  -i, --inventory=  inventory file or url
  -u, --user=       ssh user
  -k, --key=        ssh key
  -e, --env=        environment variables for all commands
      --skip=       skip commands
      --only=       run only commands
      --dry         dry run
  -v, --verbose     verbose mode
      --dbg         debug mode
  -h, --help        show help

Arguments:
  command:          run ad-hoc command on target hosts
```

This MR fixes it:

```
$ ~/git/spot/app/app --help
spot latest
Usage:
  app [command]

Application Options:
  -p, --playbook=   playbook file (default: spot.yml) [$SPOT_PLAYBOOK]
  -t, --task=       task name
  -d, --target=     target name (default: default)
  -c, --concurrent= concurrent tasks (default: 1)
      --timeout=    ssh timeout (default: 30s)
  -i, --inventory=  inventory file or url [$SPOT_INVENTORY]
  -u, --user=       ssh user
  -k, --key=        ssh key
  -e, --env=        environment variables for all commands
      --skip=       skip commands
      --only=       run only commands
      --dry         dry run
  -v, --verbose     verbose mode
      --dbg         debug mode
  -h, --help        show help

Arguments:
  command:          run ad-hoc command on target hosts
```