### PR TITLE
support of mcopy command type

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Spot supports the following command types:
 
 - `script`: can be any valid shell script. The script will be executed on the remote host(s) using SSH, inside a shell.
 - `copy`: copies a file from the local machine to the remote host(s). Example: `copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}`. If `mkdir` is set to `true` the command will create the destination directory if it doesn't exist, same as `mkdir -p` in bash.
+- `mcopy`: copies multiple files from the local machine to the remote host(s). Example: `mcopy: [{"src": "testdata/1.yml", "dst": "/tmp/1.yml", "mkdir": true}, {"src": "testdata/1.txt", "dst": "/tmp/1.txt"}]`. This is just a shortcut for multiple `copy` commands.
 - `sync`: syncs directory from the local machine to the remote host(s). Optionally supports deleting files on the remote host(s) that don't exist locally. Example: `sync: {"src": "testdata", "dst": "/tmp/things", "delete": true}`
 - `delete`: deletes a file or directory on the remote host(s), optionally can remove recursively. Example: `delete: {"path": "/tmp/things", "recur": true}`
 - `wait`: waits for the specified command to finish on the remote host(s) with 0 error code. This command is useful when you need to wait for a service to start before executing the next command. Allows to specify the timeout as well as check interval. Example: `wait: {"cmd": "curl -s --fail localhost:8080", "timeout": "30s", "interval": "1s"}`

--- a/app/config/command.go
+++ b/app/config/command.go
@@ -14,6 +14,7 @@ import (
 type Cmd struct {
 	Name        string            `yaml:"name" toml:"name"`
 	Copy        CopyInternal      `yaml:"copy" toml:"copy"`
+	MCopy       []CopyInternal    `yaml:"mcopy" toml:"mcopy"`
 	Sync        SyncInternal      `yaml:"sync" toml:"sync"`
 	Delete      DeleteInternal    `yaml:"delete" toml:"delete"`
 	Wait        WaitInternal      `yaml:"wait" toml:"wait"`

--- a/app/runner/runner_test.go
+++ b/app/runner/runner_test.go
@@ -37,7 +37,7 @@ func TestProcess_Run(t *testing.T) {
 	}
 	res, err := p.Run(ctx, "task1", hostAndPort)
 	require.NoError(t, err)
-	assert.Equal(t, 6, res.Commands)
+	assert.Equal(t, 7, res.Commands)
 	assert.Equal(t, 1, res.Hosts)
 }
 
@@ -82,7 +82,7 @@ func TestProcess_RunDry(t *testing.T) {
 	}
 	res, err := p.Run(ctx, "task1", hostAndPort)
 	require.NoError(t, err)
-	assert.Equal(t, 6, res.Commands)
+	assert.Equal(t, 7, res.Commands)
 	assert.Equal(t, 1, res.Hosts)
 }
 
@@ -151,7 +151,7 @@ func TestProcess_RunSkip(t *testing.T) {
 	}
 	res, err := p.Run(ctx, "task1", hostAndPort)
 	require.NoError(t, err)
-	assert.Equal(t, 4, res.Commands)
+	assert.Equal(t, 5, res.Commands)
 	assert.Equal(t, 1, res.Hosts)
 }
 

--- a/app/runner/testdata/conf.yml
+++ b/app/runner/testdata/conf.yml
@@ -17,6 +17,11 @@ tasks:
       - name: copy configuration
         copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}
 
+      - name: copy multiple files
+        mcopy:
+          - {src: "testdata/conf2.yml", dst: "/tmp/conf2.yml"}
+          - {src: "testdata/conf-local.yml", dst: "/tmp/conf3.yml"}
+
       - name: sync things
         sync: {"src": "testdata", "dst": "/tmp/things"}
 


### PR DESCRIPTION
This PR adds `mcopy` command type, which is a list of current `copy` commands, i.e

```yml
- name: copy many files
   mcopy:
      - {src: file1, dst:/srv/file1}
      - {src: file2, dst:/srv/file2}
```

This seems to be a task we may need often, and the current solution with multiple copy commands can be too long if many files involved