### PR TITLE
Cmd custom unmarshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,12 @@ tasks:
       
       - name: copy configuration
         copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}
-      
+
+      - name: copy other files
+        copy:
+          - {"src": "testdata/f1.csv", "dst": "/tmp/things/f1.csv", "recur": true}
+          - {"src": "testdata/f2.csv", "dst": "/tmp/things/f2.csv", "recur": true}
+
       - name: sync things
         sync: {"src": "testdata", "dst": "/tmp/things"}
       
@@ -158,6 +163,11 @@ task:
   
   - name: copy configuration
     copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}
+  
+  - name: copy other files
+    copy: 
+      - {"src": "testdata/f1.csv", "dst": "/tmp/things/f1.csv", "recur": true}
+      - {"src": "testdata/f2.csv", "dst": "/tmp/things/f2.csv", "recur": true}
   
   - name: sync things
     sync: {"src": "testdata", "dst": "/tmp/things"}
@@ -216,7 +226,7 @@ All tasks are executed sequentially one a given host, one after another. If a ta
 Spot supports the following command types:
 
 - `script`: can be any valid shell script. The script will be executed on the remote host(s) using SSH, inside a shell.
-- `copy`: copies a file from the local machine to the remote host(s). Example: `copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}`. If `mkdir` is set to `true` the command will create the destination directory if it doesn't exist, same as `mkdir -p` in bash.
+- `copy`: copies a file from the local machine to the remote host(s). Example: `copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}`. If `mkdir` is set to `true` the command will create the destination directory if it doesn't exist, same as `mkdir -p` in bash. Note: `copy` command type supports multiple commands too, the same way as `mcopy` below.
 - `mcopy`: copies multiple files from the local machine to the remote host(s). Example: `mcopy: [{"src": "testdata/1.yml", "dst": "/tmp/1.yml", "mkdir": true}, {"src": "testdata/1.txt", "dst": "/tmp/1.txt"}]`. This is just a shortcut for multiple `copy` commands.
 - `sync`: syncs directory from the local machine to the remote host(s). Optionally supports deleting files on the remote host(s) that don't exist locally. Example: `sync: {"src": "testdata", "dst": "/tmp/things", "delete": true}`
 - `delete`: deletes a file or directory on the remote host(s), optionally can remove recursively. Example: `delete: {"path": "/tmp/things", "recur": true}`

--- a/app/config/playbook.go
+++ b/app/config/playbook.go
@@ -130,7 +130,7 @@ func New(fname string, overrides *Overrides) (res *PlayBook, err error) {
 	log.Printf("[INFO] playbook loaded with %d tasks", len(res.Tasks))
 	for _, tsk := range res.Tasks {
 		for _, c := range tsk.Commands {
-			log.Printf("[DEBUG] load task %s command %s", tsk.Name, c.Name)
+			log.Printf("[DEBUG] load task %q, command %q", tsk.Name, c.Name)
 		}
 	}
 
@@ -439,12 +439,12 @@ func (p *PlayBook) targetHosts(name string) ([]Destination, error) {
 		if err != nil {
 			return nil, fmt.Errorf("can't parse port %s: %w", elems[1], err)
 		}
-		log.Printf("[DEBUG] target %q found as host:port %s:%d", name, elems[0], port)
+		log.Printf("[DEBUG] target %q used as host:port %s:%d", name, elems[0], port)
 		return []Destination{{Host: elems[0], Port: port, User: p.User}}, nil
 	}
 
 	// finally we assume it is a host name, with default port 22
-	log.Printf("[DEBUG] target %q found as host:22 %s", name, name)
+	log.Printf("[DEBUG] target %q used as host:22 %s", name, name)
 	return []Destination{{Host: name, Port: 22, User: p.User}}, nil
 }
 

--- a/app/runner/runner.go
+++ b/app/runner/runner.go
@@ -53,13 +53,13 @@ func (p *Process) Run(ctx context.Context, task, target string) (s ProcStats, er
 	if err != nil {
 		return ProcStats{}, fmt.Errorf("can't get task %s: %w", task, err)
 	}
-	log.Printf("[DEBUG] task %s has %d commands", task, len(tsk.Commands))
+	log.Printf("[DEBUG] task %q has %d commands", task, len(tsk.Commands))
 
 	targetHosts, err := p.Config.TargetHosts(target)
 	if err != nil {
 		return ProcStats{}, fmt.Errorf("can't get target %s: %w", target, err)
 	}
-	log.Printf("[DEBUG] target hosts %v", targetHosts)
+	log.Printf("[DEBUG] target hosts %+v", targetHosts)
 
 	wg := syncs.NewErrSizedGroup(p.Concurrency, syncs.Context(ctx), syncs.Preemptive)
 	var commands int32

--- a/app/runner/runner_test.go
+++ b/app/runner/runner_test.go
@@ -59,7 +59,7 @@ func TestProcess_RunSimplePlaybook(t *testing.T) {
 	}
 	res, err := p.Run(ctx, "default", hostAndPort)
 	require.NoError(t, err)
-	assert.Equal(t, 6, res.Commands)
+	assert.Equal(t, 7, res.Commands)
 	assert.Equal(t, 1, res.Hosts)
 }
 

--- a/app/runner/testdata/conf-simple.yml
+++ b/app/runner/testdata/conf-simple.yml
@@ -9,6 +9,11 @@ task:
   - name: copy configuration
     copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}
 
+  - name: copy with multiple files
+    copy:
+      - {"src": "testdata/conf2.yml", "dst": "/tmp/conf2.yml", "mkdir": true}
+      - {"src": "testdata/conf-local.yml", "dst": "/tmp/conf-local.yml", "mkdir": true}
+
   - name: sync things
     sync: {"src": "testdata", "dst": "/tmp/things"}
 


### PR DESCRIPTION
This PR provides a custom unmarshaler for the command. The goal is to allow to use of either a single element or list in `copy` 

```yml
  copy: {src: "f1", "dst":f2}

  copy:
    - {src: "f10", "dst":f20}
    - {src: "f11", "dst":f21}
```

The `mcopy` still exists, so it can be used the same as before. Internally this custom unmarshaler fills either `Copy` or `MCopy` fields, so this custom magic is isolated to the config parser only, and other parts of the system just see the regular `Copy` and `MCopy` fields