### PR TITLE
simple sudo implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Each command type supports the following options:
 - `ignore_errors`: if set to `true` the command will not fail the task in case of an error.
 - `no_auto`: if set to `true` the command will not be executed automatically, but can be executed manually using the `--only` flag.
 - `local`: if set to `true` the command will be executed on the local host (the one running the `spot` command) instead of the remote host(s).
+- `sudo`: if set to `true` the script command will be executed with `sudo` privileges.
 
 example setting `ignore_errors` and `no_auto` options:
 
@@ -255,6 +256,9 @@ example setting `ignore_errors` and `no_auto` options:
         script: sleep 5s
         options: {ignore_errors: true, no_auto: true}
 ```
+
+Please note that the `sudo` option is only supported for the `script` command type. This limitation exists because there is no direct and universal method for uploading files over SFTP with sudo privileges. As a workaround, users can first use the `copy` command to transfer files to a temporary location, and then execute a `script` command with `sudo: true` to move those files to their final destination. Alternatively, using the root user directly in the playbook will allow direct file transfer to any restricted location and enable running privileged commands without the need to use sudo.
+
 
 ### Script Execution
 

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -33,6 +33,7 @@ type CmdOptions struct {
 	IgnoreErrors bool     `yaml:"ignore_errors" toml:"ignore_errors"`
 	NoAuto       bool     `yaml:"no_auto" toml:"no_auto"`
 	Local        bool     `yaml:"local" toml:"local"`
+	Sudo         bool     `yaml:"sudo" toml:"sudo"`
 	Secrets      []string `yaml:"secrets" toml:"secrets"`
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -203,6 +203,10 @@ func (p *Process) execCommand(ctx context.Context, ep execCmdParams) (details st
 			}
 		}()
 		details = fmt.Sprintf(" {script: %s}", c)
+		if ep.cmd.Options.Sudo {
+			details = fmt.Sprintf(" {script: %s, sudo: true}", c)
+			c = fmt.Sprintf("sudo bash -c %q", c)
+		}
 		if _, err := ep.exec.Run(ctx, c, p.Verbose); err != nil {
 			return details, fmt.Errorf("can't run script on %s: %w", ep.hostAddr, err)
 		}

--- a/pkg/runner/testdata/conf.yml
+++ b/pkg/runner/testdata/conf.yml
@@ -42,6 +42,16 @@ tasks:
         script: echo "no auto cmd"
         options: {no_auto: true}
 
+      - name: root only multiline
+        script: |
+          echo "root only"
+          ls -l /etc
+        options: {no_auto: true, sudo: true}
+
+      - name: root only single line
+        script: ls -l /etc
+        options: {no_auto: true, sudo: true}
+
   - name: failed_task
     commands:
       - name: good command


### PR DESCRIPTION
This PR addresses #60 and introduces the `options.sudo` field, allowing users to run `script` commands with elevated privileges. However, this implementation is limited, as enabling sudo for `copy` and `mcopy` commands is significantly more complex. It would require copying files to a temporary location and then executing a move command to transfer them to their final destination. Additionally, supporting glob patterns further complicates the task. Implementing sudo for the sync command is unclear, and how this could be achieved is not immediately apparent.

Considering these limitations, restricting the `sudo` option to the `script` command type is a reasonable trade-off. If users need to deploy substantial resources to root-only locations, using the root user directly is likely more efficient.
