### PR TITLE
Add sudo support to copy, mcopy, delete and wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Each command type supports the following options:
 - `ignore_errors`: if set to `true` the command will not fail the task in case of an error.
 - `no_auto`: if set to `true` the command will not be executed automatically, but can be executed manually using the `--only` flag.
 - `local`: if set to `true` the command will be executed on the local host (the one running the `spot` command) instead of the remote host(s).
-- `sudo`: if set to `true` the script command will be executed with `sudo` privileges.
+- `sudo`: if set to `true` the command will be executed with `sudo` privileges.
 
 example setting `ignore_errors` and `no_auto` options:
 
@@ -257,7 +257,7 @@ example setting `ignore_errors` and `no_auto` options:
         options: {ignore_errors: true, no_auto: true}
 ```
 
-Please note that the `sudo` option is only supported for the `script` command type. This limitation exists because there is no direct and universal method for uploading files over SFTP with sudo privileges. As a workaround, users can first use the `copy` command to transfer files to a temporary location, and then execute a `script` command with `sudo: true` to move those files to their final destination. Alternatively, using the root user directly in the playbook will allow direct file transfer to any restricted location and enable running privileged commands without the need to use sudo.
+Please note that the `sudo` option is not supported for the `sync` command type, but all other command types support it.
 
 
 ### Script Execution

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -73,17 +73,17 @@ func (cmd *Cmd) GetScript() (string, io.Reader) {
 	elems := strings.Split(cmd.Script, "\n")
 	if len(elems) > 1 {
 		log.Printf("[DEBUG] command %q is multiline, using script file", cmd.Name)
-		return "", cmd.getScriptFile()
+		return "", cmd.scriptFile(cmd.Script)
 	}
 
 	log.Printf("[DEBUG] command %q is single line, using script string", cmd.Name)
-	return cmd.getScriptCommand(), nil
+	return cmd.scriptCommand(cmd.Script), nil
 }
 
 // GetScriptCommand concatenates all script line in commands into one a string to be executed by shell.
 // Empty string is returned if no script is defined.
-func (cmd *Cmd) getScriptCommand() string {
-	if cmd.Script == "" {
+func (cmd *Cmd) scriptCommand(inp string) string {
+	if inp == "" {
 		return ""
 	}
 
@@ -100,7 +100,7 @@ func (cmd *Cmd) getScriptCommand() string {
 		res += strings.Join(secrets, " ") + " "
 	}
 
-	elems := strings.Split(cmd.Script, "\n")
+	elems := strings.Split(inp, "\n")
 	var parts []string // nolint
 	for _, el := range elems {
 		c := strings.TrimSpace(el)
@@ -118,7 +118,7 @@ func (cmd *Cmd) getScriptCommand() string {
 
 // GetScriptFile returns a reader for script file. All the line in the command used as a script, with hashbang,
 // set -e and environment variables.
-func (cmd *Cmd) getScriptFile() io.Reader {
+func (cmd *Cmd) scriptFile(inp string) io.Reader {
 	var buf bytes.Buffer
 
 	buf.WriteString("#!/bin/sh\n") // add hashbang
@@ -133,7 +133,7 @@ func (cmd *Cmd) getScriptFile() io.Reader {
 		}
 	}
 
-	elems := strings.Split(cmd.Script, "\n")
+	elems := strings.Split(inp, "\n")
 	for _, el := range elems {
 		c := strings.TrimSpace(el)
 		if len(c) < 2 {

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -123,21 +123,21 @@ func TestCmd_getScriptCommand(t *testing.T) {
 	t.Run("script", func(t *testing.T) {
 		cmd := c.Tasks[0].Commands[3]
 		assert.Equal(t, "git", cmd.Name, "name")
-		res := cmd.getScriptCommand()
+		res := cmd.scriptCommand(cmd.Script)
 		assert.Equal(t, `sh -c "git clone https://example.com/remark42.git /srv || true; cd /srv; git pull"`, res)
 	})
 
 	t.Run("no-script", func(t *testing.T) {
 		cmd := c.Tasks[0].Commands[1]
 		assert.Equal(t, "copy configuration", cmd.Name)
-		res := cmd.getScriptCommand()
+		res := cmd.scriptCommand(cmd.Script)
 		assert.Equal(t, "", res)
 	})
 
 	t.Run("script with env", func(t *testing.T) {
 		cmd := c.Tasks[0].Commands[4]
 		assert.Equal(t, "docker", cmd.Name)
-		res := cmd.getScriptCommand()
+		res := cmd.scriptCommand(cmd.Script)
 		assert.Equal(t, `sh -c "BAR='qux' FOO='bar' docker pull umputun/remark42:latest; docker stop remark42 || true; docker rm remark42 || true; docker run -d --name remark42 -p 8080:8080 umputun/remark42:latest"`, res)
 	})
 }
@@ -212,7 +212,7 @@ func TestCmd_getScriptFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reader := tt.cmd.getScriptFile()
+			reader := tt.cmd.scriptFile(tt.cmd.Script)
 			scriptContentBytes, err := io.ReadAll(reader)
 			assert.NoError(t, err)
 			scriptContent := string(scriptContentBytes)

--- a/pkg/runner/testdata/conf.yml
+++ b/pkg/runner/testdata/conf.yml
@@ -55,6 +55,23 @@ tasks:
         script: ls -l /etc
         options: {no_auto: true, sudo: true}
 
+      - name: root only copy single file
+        copy: {src: testdata/conf.yml, dst: /srv/conf.yml}
+        options: {no_auto: true, sudo: true}
+
+      - name: root only copy multiple files
+        copy: {src: testdata/*.yml, dst: /srv}
+        options: {no_auto: true, sudo: true}
+
+      - name: root only stat /srv/conf.yml
+        script: stat /srv/conf.yml
+        options: {no_auto: true, sudo: true}
+
+      - name: root only ls /srv
+        script: ls -la /srv
+        options: {no_auto: true, sudo: true}
+
+
   - name: failed_task
     commands:
       - name: good command


### PR DESCRIPTION
This pr related to #62 and discussion #60 

It adds support of `sudo:true` options for all copy (single/multi and `mcopy`) and to delete (both single file and recursive) as well as to `wait` command

_The only command left without sudo support is `sync` and i don't have a good idea how this one can be done_