### PR TITLE
implement support of passing all exported vars to other commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,23 @@ echo "All done! $FOO $BAR"
 
 By using this approach, Spot enables users to write and execute more complex scripts, providing greater flexibility and power in managing remote hosts or local environments.
 
+### Passing variables from one script command to another
+
+Spot allows passing variables from one script command to another. This is useful when you need to pass the output of one command to another command. For example if one command creates a file and you need to pass the file name to another command. To pass such variables, user need to use usual shell's `export` command in the first script command, and then all the variables exported in the first command will be available in the subsequent commands. 
+
+For example:
+
+```yaml
+commands:
+  - name: first command
+    script: |
+      export FILE_NAME=/tmp/file1
+      touch $FILE_NAME
+  - name: second command
+    script: |
+      echo "File name is $FILE_NAME"
+```
+
 ## Targets
 
 Targets are used to define the remote hosts to execute the tasks on. Targets can be defined in the playbook file or passed as a command-line argument. The following target types are supported:

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -41,6 +41,27 @@ echo 'Goodbye, World!'`,
 			},
 		},
 		{
+			name: "multiline command with exports",
+			cmd: &Cmd{
+				Script: `echo 'Hello, World!'
+export FOO='bar'
+echo 'Goodbye, World!'
+export BAR='foo'
+`,
+			},
+			expectedScript: "",
+			expectedContents: []string{
+				"#!/bin/sh",
+				"set -e",
+				"echo 'Hello, World!'",
+				"export FOO='bar'",
+				"echo 'Goodbye, World!'",
+				"export BAR='foo'",
+				"echo setvar FOO=${FOO}",
+				"echo setvar BAR=${BAR}",
+			},
+		},
+		{
 			name: "single line command with environment variables",
 			cmd: &Cmd{
 				Script: "echo $GREETING",
@@ -101,7 +122,6 @@ echo 'Goodbye, World!'`,
 		t.Run(tc.name, func(t *testing.T) {
 			script, reader := tc.cmd.GetScript()
 			assert.Equal(t, tc.expectedScript, script)
-
 			if reader != nil {
 				contents, err := io.ReadAll(reader)
 				assert.NoError(t, err)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -180,6 +180,9 @@ func (p *Process) runTaskOnHost(ctx context.Context, tsk *config.Task, hostAddr,
 					if env == nil {
 						env = make(map[string]string)
 					}
+					if _, ok := env[k]; ok { // don't allow override variables
+						continue
+					}
 					env[k] = v
 					tsk.Commands[i].Environment = env
 				}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -133,6 +133,7 @@ func TestProcess_Run(t *testing.T) {
 		assert.Equal(t, 3, res.Commands)
 		assert.Contains(t, outWriter.String(), `> var foo: 6`)
 		assert.Contains(t, outWriter.String(), `> var bar: 9`)
+		assert.Contains(t, outWriter.String(), `> var baz: qux`, "was not overwritten")
 	})
 }
 

--- a/pkg/runner/testdata/conf.yml
+++ b/pkg/runner/testdata/conf.yml
@@ -27,6 +27,8 @@ tasks:
 
       - name: some command
         script: |
+          export foo=$((1 + 2 + 3))
+          export bar=$((4 + 5))
           ls -laR /tmp
           du -hcs /srv
           cat /tmp/conf.yml
@@ -34,6 +36,13 @@ tasks:
 
       - name: runtime variables
         script: echo host:"{SPOT_REMOTE_HOST}", name:"{SPOT_REMOTE_NAME}", cmd:"{SPOT_COMMAND}", user:"{SPOT_REMOTE_USER}", task:"{SPOT_TASK}"
+
+      - name: user variables
+        script: |
+          env
+          echo "var foo: ${foo}"
+          echo "var bar: ${bar}"
+        options: {no_auto: true, sudo: true}
 
       - name: delete things
         delete: {"path": "/tmp/things", "recur": true}

--- a/pkg/runner/testdata/conf.yml
+++ b/pkg/runner/testdata/conf.yml
@@ -29,6 +29,7 @@ tasks:
         script: |
           export foo=$((1 + 2 + 3))
           export bar=$((4 + 5))
+          export baz=zzzzz
           ls -laR /tmp
           du -hcs /srv
           cat /tmp/conf.yml
@@ -42,6 +43,8 @@ tasks:
           env
           echo "var foo: ${foo}"
           echo "var bar: ${bar}"
+          echo "var baz: ${baz}"
+        env: {baz: qux}
         options: {no_auto: true, sudo: true}
 
       - name: delete things


### PR DESCRIPTION
This PR adds ability to export some variables in one command and get it from env of the another command. From user's point of view this should be expected behavior and it feels like all the commands run in the same shell script. However, internally command detects all the exports inside the script and append result of evaluation of those variables to the end of the executed script as `echo setvar foo=bar`

After the command executed those `setvar` extracted and set to all other commands as a regular env.

This snippet indicates the possible use-case:

```yml
      - name: some command
        script: |
          export foo=$((1 + 2 + 3))
          export bar=$((4 + 5))
          export baz=zzzzz
          ls -laR /tmp
          du -hcs /srv
          cat /tmp/conf.yml
          echo all good, 123

      - name: user variables
        script: |
          env
          echo "var foo: ${foo}"
          echo "var bar: ${bar}"
          echo "var baz: ${baz}"
        env: {baz: qux}
```

In this example the first command export foo, bar and baz variables. `foo` and `bar` are evaluated, but `baz` is not because it set directly by `env`. It is not clear to me if this override should be allowed, but i feel it could be a source for confusion, so for now it will keep the original (`qux`) value

The next command, i.e. "user variables" will get all those vars and will print 

```
var foo: 6
var bar: 9
var baz: qux
```