### PR TITLE
Removed duplicates from --help

### DIFF
--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -52,7 +52,6 @@ type options struct {
 	Dry     bool `long:"dry" description:"dry run"`
 	Verbose bool `short:"v" long:"verbose" description:"verbose mode"`
 	Dbg     bool `long:"dbg" description:"debug mode"`
-	Help    bool `short:"h" long:"help" description:"show help"`
 }
 
 // SecretsProvider defines secrets provider options, for all supported providers


### PR DESCRIPTION
Here is what `--help` output now:

```
besarabov@bessarabov-osx:~/git/spot/cmd/spot$ ./spot --help
spot latest
Usage:
  spot [OPTIONS] [command]

Application Options:
  -p, --playbook=                              playbook file (default: spot.yml) [$SPOT_PLAYBOOK]
      --task=                                  task name
  -t, --target=                                target name (default: default)
  -c, --concurrent=                            concurrent tasks (default: 1)
      --timeout=                               ssh timeout (default: 30s) [$SPOT_TIMEOUT]
  -i, --inventory=                             inventory file or url [$SPOT_INVENTORY]
  -u, --user=                                  ssh user
  -k, --key=                                   ssh key
  -e, --env=                                   environment variables for all commands
      --skip=                                  skip commands
      --only=                                  run only commands
      --dry                                    dry run
  -v, --verbose                                verbose mode
      --dbg                                    debug mode
  -h, --help                                   show help

secrets:
      --secrets.provider=[none|spot|vault|aws] secret provider type (default: none) [$SPOT_SECRETS_PROVIDER]
      --secrets.key=                           secure key for spot secrets provider [$SPOT_SECRETS_KEY]
      --secrets.conn=                          connection string for spot secrets provider (default: spot.db) [$SPOT_SECRETS_CONN]

vault:
      --secrets.vault.token=                   vault token [$SPOT_SECRETS_VAULT_TOKEN]
      --secrets.vault.path=                    vault path [$SPOT_SECRETS_VAULT_PATH]
      --secrets.vault.url=                     vault url [$SPOT_SECRETS_VAULT_URL]

aws:
      --secrets.aws.region=                    aws region [$SPOT_SECRETS_AWS_REGION]
      --secrets.aws.access-key=                aws access key [$SPOT_SECRETS_AWS_ACCESS_KEY]
      --secrets.aws.secret-key=                aws secret key [$SPOT_SECRETS_AWS_SECRET_KEY]

Help Options:
  -h, --help                                   Show this help message

Arguments:
  command:                                     run ad-hoc command on target hosts
```

As you can see the `-h, --help` is duplicated in 2 groups:

 * `Application Options:`
 *  `Help Options:`
 
This PR removed `-h, --help` from `Application Options:`

The output of the `--help` with the code from this MR:

```
besarabov@bessarabov-osx:~/git/spot/cmd/spot$ ./spot --help
spot latest
Usage:
  spot [OPTIONS] [command]

Application Options:
  -p, --playbook=                              playbook file (default: spot.yml) [$SPOT_PLAYBOOK]
      --task=                                  task name
  -t, --target=                                target name (default: default)
  -c, --concurrent=                            concurrent tasks (default: 1)
      --timeout=                               ssh timeout (default: 30s) [$SPOT_TIMEOUT]
  -i, --inventory=                             inventory file or url [$SPOT_INVENTORY]
  -u, --user=                                  ssh user
  -k, --key=                                   ssh key
  -e, --env=                                   environment variables for all commands
      --skip=                                  skip commands
      --only=                                  run only commands
      --dry                                    dry run
  -v, --verbose                                verbose mode
      --dbg                                    debug mode

secrets:
      --secrets.provider=[none|spot|vault|aws] secret provider type (default: none) [$SPOT_SECRETS_PROVIDER]
      --secrets.key=                           secure key for spot secrets provider [$SPOT_SECRETS_KEY]
      --secrets.conn=                          connection string for spot secrets provider (default: spot.db) [$SPOT_SECRETS_CONN]

vault:
      --secrets.vault.token=                   vault token [$SPOT_SECRETS_VAULT_TOKEN]
      --secrets.vault.path=                    vault path [$SPOT_SECRETS_VAULT_PATH]
      --secrets.vault.url=                     vault url [$SPOT_SECRETS_VAULT_URL]

aws:
      --secrets.aws.region=                    aws region [$SPOT_SECRETS_AWS_REGION]
      --secrets.aws.access-key=                aws access key [$SPOT_SECRETS_AWS_ACCESS_KEY]
      --secrets.aws.secret-key=                aws secret key [$SPOT_SECRETS_AWS_SECRET_KEY]

Help Options:
  -h, --help                                   Show this help message

Arguments:
  command:                                     run ad-hoc command on target hosts
```
