### PR TITLE
Allow user in target address

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ in this example, the playbook will be executed on hosts named `host1` and `host2
 There are several ways to override or alter the target defined in the playbook file via command-line arguments:
 
 - `--inventory` set hosts from the provided inventory file or url. Example: `--inventory=inventory.yml` or `--inventory=http://localhost:8080/inventory`.
-- `--target` set groups, names, tags from inventory or directly hosts to run playbook on. Example: `--target=prod` (will run on all hosts in group `prod`) or `--target=example.com:2222` (will run on host `example.com` with port `2222`).
+- `--target` set groups, names, tags from inventory or directly hosts to run playbook on. Example: `--target=prod` (will run on all hosts in group `prod`) or `--target=example.com:2222` (will run on host `example.com` with port `2222`). User name can be provided as a part of the direct target address as well, i.e. `--target=user2@example.com:2222`
 - `--user` set the ssh user to run the playbook on remote hosts. Example: `--user=test`.
 - `--key` set the ssh key to run the playbook on remote hosts. Example: `--key=/path/to/key`.
 

--- a/pkg/config/playbook.go
+++ b/pkg/config/playbook.go
@@ -456,7 +456,16 @@ func (p *PlayBook) targetHosts(name string) ([]Destination, error) {
 		}
 	}
 
-	// try as single host or host:port
+	// try as single host or host:port or user@host:port
+	user := p.User
+	if strings.Contains(name, "@") { // extract user from name
+		elems := strings.Split(name, "@")
+		user = elems[0]
+		if len(elems) > 1 {
+			name = elems[1] // skip user part
+		}
+	}
+
 	if strings.Contains(name, ":") {
 		elems := strings.Split(name, ":")
 		port, err := strconv.Atoi(elems[1])
@@ -464,12 +473,12 @@ func (p *PlayBook) targetHosts(name string) ([]Destination, error) {
 			return nil, fmt.Errorf("can't parse port %s: %w", elems[1], err)
 		}
 		log.Printf("[DEBUG] target %q used as host:port %s:%d", name, elems[0], port)
-		return []Destination{{Host: elems[0], Port: port, User: p.User}}, nil
+		return []Destination{{Host: elems[0], Port: port, User: user}}, nil
 	}
 
 	// finally we assume it is a host name, with default port 22
 	log.Printf("[DEBUG] target %q used as host:22 %s", name, name)
-	return []Destination{{Host: name, Port: 22, User: p.User}}, nil
+	return []Destination{{Host: name, Port: 22, User: user}}, nil
 }
 
 // loadInventoryFile loads inventory from file or url and returns a struct with groups.

--- a/pkg/config/playbook_test.go
+++ b/pkg/config/playbook_test.go
@@ -302,6 +302,16 @@ func TestTargetHosts(t *testing.T) {
 			[]Destination{{Host: "host2.example.com", Port: 22, User: "defaultuser", Name: "host2", Tags: []string{"tag1"}}},
 			false,
 		},
+		{
+			"target as single host address with user", "user2@host5.example.com", nil,
+			[]Destination{{Host: "host5.example.com", Port: 22, User: "user2"}},
+			false,
+		},
+		{
+			"target as single host address, port and user", "user2@host5.example.com:2345", nil,
+			[]Destination{{Host: "host5.example.com", Port: 2345, User: "user2"}},
+			false,
+		},
 		{"invalid host:port format", "host5.example.com:invalid", nil, nil, true},
 		{"random host without a port", "host5.example.com", nil,
 			[]Destination{{Host: "host5.example.com", Port: 22, User: "defaultuser"}},


### PR DESCRIPTION
This PR supports users in direct target address, i.e `user@example.com:22`

see #73 