### PR TITLE
don't treat targets set in simple pb as names if no inventory set

### DIFF
--- a/pkg/config/playbook_test.go
+++ b/pkg/config/playbook_test.go
@@ -108,7 +108,7 @@ func TestPlaybook_New(t *testing.T) {
 		require.ErrorContains(t, err, `duplicate task name "deploy"`)
 	})
 
-	t.Run("simple playbook", func(t *testing.T) {
+	t.Run("simple playbook with inventory", func(t *testing.T) {
 		c, err := New("testdata/simple-playbook.yml", nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(c.Tasks), "1 task")
@@ -118,6 +118,19 @@ func TestPlaybook_New(t *testing.T) {
 		assert.Equal(t, 1, len(c.Targets))
 		assert.Equal(t, []string{"name1", "name2"}, c.Targets["default"].Names)
 		assert.Equal(t, []Destination{{Host: "127.0.0.1", Port: 2222}}, c.Targets["default"].Hosts)
+	})
+
+	t.Run("simple playbook without inventory", func(t *testing.T) {
+		c, err := New("testdata/simple-playbook-no-inventory.yml", nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(c.Tasks), "1 task")
+		assert.Equal(t, "default", c.Tasks[0].Name, "task name")
+		assert.Equal(t, 5, len(c.Tasks[0].Commands), "5 commands")
+
+		assert.Equal(t, 1, len(c.Targets))
+		assert.Equal(t, 0, len(c.Targets["default"].Names))
+		assert.Equal(t, []Destination{{Host: "name1", Port: 22}, {Host: "192.168.1.1", Port: 22},
+			{Host: "127.0.0.1", Port: 2222}}, c.Targets["default"].Hosts)
 	})
 
 	t.Run("playbook with secrets", func(t *testing.T) {

--- a/pkg/config/testdata/simple-playbook-no-inventory.yml
+++ b/pkg/config/testdata/simple-playbook-no-inventory.yml
@@ -1,0 +1,37 @@
+user: app
+ssh_key: ~/.ssh/id_rsa
+
+targets: ["name1", "192.168.1.1", "127.0.0.1:2222"]
+
+task:
+  - name: wait
+    script: sleep 5
+
+  - name: copy configuration
+    copy: {"src": "/local/remark42.yml", "dst": "/srv/remark42.yml", "mkdir": true}
+
+  - name: some local command
+    options: {local: true}
+    script: |
+      ls -la /srv
+      du -hcs /srv
+
+  - name: git
+    before: "echo before git"
+    after: "echo after git"
+    onerror: "echo onerror git"
+    script: |
+      git clone https://example.com/remark42.git /srv || true # clone if doesn't exists, but don't fail if exists
+      cd /srv
+      git pull
+
+  - name: docker
+    options: {no_auto: true}
+    script: |
+      docker pull umputun/remark42:latest
+      docker stop remark42 || true
+      docker rm remark42 || true
+      docker run -d --name remark42 -p 8080:8080 umputun/remark42:latest
+    env:
+      FOO: bar
+      BAR: qux


### PR DESCRIPTION
This PR treats all targets set in a simplified playbook as addresses in case inventory is not set. See discussion in #75 