### PR TITLE
extend template substitution to env for all command type

### DIFF
--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -71,7 +71,8 @@ func (cmd *Cmd) GetScript() (command string, rdr io.Reader) {
 	}
 
 	elems := strings.Split(cmd.Script, "\n")
-	if len(elems) > 1 {
+	// export should be treated as multiline for env vars to be set
+	if len(elems) > 1 || strings.Contains(cmd.Script, "export") {
 		log.Printf("[DEBUG] command %q is multiline, using script file", cmd.Name)
 		return "", cmd.scriptFile(cmd.Script)
 	}

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -116,6 +116,19 @@ echo 'Goodbye, World!'`,
 			expectedScript:   "",
 			expectedContents: nil,
 		},
+		{
+			name: "single line command with export",
+			cmd: &Cmd{
+				Script: "export GREETING='Hello, World!'",
+			},
+			expectedScript: "",
+			expectedContents: []string{
+				"#!/bin/sh",
+				"set -e",
+				"export GREETING='Hello, World!'",
+				"echo setvar GREETING=${GREETING}",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/runner/commands_test.go
+++ b/pkg/runner/commands_test.go
@@ -83,6 +83,17 @@ func Test_templaterApply(t *testing.T) {
 			expected: "example.com blah task1 user2:ls",
 		},
 		{
+			name: "env variables",
+			inp:  "${FOO} blah $BAR ${SPOT_REMOTE_USER}:${SPOT_COMMAND}",
+			tmpl: templater{
+				hostAddr: "example.com",
+				command:  "ls",
+				task:     &config.Task{Name: "task1", User: "user2"},
+				env:      map[string]string{"FOO": "foo_val", "BAR": "bar_val"},
+			},
+			expected: "foo_val blah bar_val user2:ls",
+		},
+		{
 			name: "with error msg",
 			inp:  "$SPOT_REMOTE_HOST:$SPOT_REMOTE_USER:$SPOT_COMMAND ${SPOT_ERROR}",
 			tmpl: templater{

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -160,6 +160,28 @@ func TestProcess_Run(t *testing.T) {
 		assert.NotContains(t, outWriter.String(), "FOO_SECRET")
 		assert.NotContains(t, outWriter.String(), "BAR_SECRET")
 	})
+
+	t.Run("set variables for copy command", func(t *testing.T) {
+		conf, err := config.New("testdata/conf.yml", nil, nil)
+		require.NoError(t, err)
+
+		p := Process{
+			Concurrency: 1,
+			Connector:   connector,
+			Config:      conf,
+			ColorWriter: executor.NewColorizedWriter(os.Stdout, "", "", "", nil),
+			Only:        []string{"set filename for copy to env", "copy filename from env"},
+		}
+
+		outWriter := &bytes.Buffer{}
+		log.SetOutput(io.MultiWriter(outWriter, os.Stderr))
+
+		res, err := p.Run(ctx, "task1", testingHostAndPort)
+		require.NoError(t, err)
+		assert.Equal(t, 2, res.Commands)
+		assert.Contains(t, outWriter.String(), ` > setvar filename=testdata/conf.yml`)
+	})
+
 }
 
 func TestProcess_RunWithSudo(t *testing.T) {

--- a/pkg/runner/testdata/conf.yml
+++ b/pkg/runner/testdata/conf.yml
@@ -90,6 +90,14 @@ tasks:
         script: ls -la /srv
         options: {no_auto: true, sudo: true}
 
+      - name: set filename for copy to env
+        script: |
+          export filename="testdata/conf.yml"
+        options: {no_auto: true, sudo: true}
+
+      - name: copy filename from env
+        copy: {src: "${filename}", dst: "/srv/conf.yml"}
+        options: {no_auto: true, sudo: true}
 
   - name: failed_task
     commands:


### PR DESCRIPTION
This PR adds expansion of environment variables to all command types. There are two primary use cases for this functionality:

- Pass env parameter in CLI defining things like `src` or `dst`, i.e. `copy: {src: "$filename.mp3", dst: "/media/someting.mp3"}`. If such playbook is called with `-e filename=myfile` it will copy `myfile.mp3`

- support passing parameters between commands, for example from `script`  to `copy`

```yml
task:
 - command: set name
   script: export filename=base($fullname)
 - command: copy file
   copy: {src: "$filename", dst:"/tmp/$filename"} 
```

both use cases are real; from my experience 