### PR TITLE
add support of task's targets set directly in playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Each task consists of a list of commands that will be executed on the remote hos
 
 - `on_error`: specifies the command to execute on the local host (the one running the `spot` command) in case of an error. The command can use the `{SPOT_ERROR}` variable to access the last error message. Example: `on_error: "curl -s localhost:8080/error?msg={SPOT_ERROR}"`
 - `user`: specifies the SSH user to use when connecting to remote hosts. Overrides the user defined in the top section of playbook file for the specified task.
+- `targets` - list of target names, group, tags or host addresses to execute the task on. Command line `-t` flag can be used to override this field. 
 
 *Note: these fields supported in the full playbook type only*
 
@@ -406,7 +407,7 @@ Targets are used to define the remote hosts to execute the tasks on. Targets can
 
 All the target types can be combined, i.e. `hosts`, `groups`, `tags`, `hosts` and `names` all can be used together in the same target. To avoid possible duplicates, the final list of hosts is deduplicated by the host+ip+user. 
 
-example of targets in the playbook file:
+example of targets set in the playbook file:
 
 ```yaml
 targets:
@@ -419,6 +420,13 @@ targets:
     names: ["host1", "host2"]
   all-servers:
     groups: ["all"]
+
+tasks:
+  - name: task1
+    targets: ["dev", "host3.example.com:2222"]
+    commands:
+      - name: command1
+        script: echo "Hello World"
 ```
 
 *Note: All the target types available in the full playbook file only. The simplified playbook file only supports a single, anonymous target type combining `hosts` and `names` together.*
@@ -449,7 +457,9 @@ The target selection is done in the following order:
   - if no match found, Spot will try to match on host name in the inventory file.
   - if no match found, Spot will try to match on host address in the playbook file.
   - if no match found, Spot will use it as a host address.
-- if `--target` is not discovered, Spot will assume the `default` target.
+- if `--target` is not set, Spot will try check it `targets` list for the task. If set, it will use it following the same logic as above.
+- and finally, Spot will assume the `default` target.
+
 
 ### Inventory 
 

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -467,6 +467,93 @@ func Test_formatErrorString(t *testing.T) {
 	}
 }
 
+func Test_targetsForTask(t *testing.T) {
+	tests := []struct {
+		name           string
+		opts           options
+		taskName       string
+		conf           *config.PlayBook
+		expectedResult []string
+	}{
+		{
+			name: "non-default targets specified on command line",
+			opts: options{
+				Targets: []string{"target1", "target2"},
+			},
+			taskName:       "task1",
+			conf:           &config.PlayBook{},
+			expectedResult: []string{"target1", "target2"},
+		},
+		{
+			name: "task with targets defined and default in command line",
+			opts: options{
+				Targets: []string{"default"},
+			},
+			taskName: "task1",
+			conf: &config.PlayBook{
+				Tasks: []config.Task{
+					{
+						Name:    "task1",
+						Targets: []string{"target3", "target4"},
+					},
+				},
+			},
+			expectedResult: []string{"target3", "target4"},
+		},
+		{
+			name: "task without targets defined",
+			opts: options{
+				Targets: []string{"default"},
+			},
+			taskName: "task2",
+			conf: &config.PlayBook{
+				Tasks: []config.Task{
+					{
+						Name:    "task1",
+						Targets: []string{"target3", "target4"},
+					},
+					{
+						Name: "task2",
+					},
+				},
+			},
+			expectedResult: []string{"default"},
+		},
+		{
+			name: "default target with no task targets",
+			opts: options{
+				Targets: []string{"default"},
+			},
+			taskName:       "task3",
+			conf:           &config.PlayBook{},
+			expectedResult: []string{"default"},
+		},
+		{
+			name: "non-existing task",
+			opts: options{
+				Targets: []string{"default"},
+			},
+			taskName: "task3",
+			conf: &config.PlayBook{
+				Tasks: []config.Task{
+					{
+						Name:    "task1",
+						Targets: []string{"target3", "target4"},
+					},
+				},
+			},
+			expectedResult: []string{"default"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := targetsForTask(tc.opts, tc.taskName, tc.conf)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
 func startTestContainer(t *testing.T) (hostAndPort string, teardown func()) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/config/playbook.go
+++ b/pkg/config/playbook.go
@@ -52,10 +52,11 @@ type SimplePlayBook struct {
 
 // Task defines multiple commands runs together
 type Task struct {
-	Name     string `yaml:"name" toml:"name"` // name of target, set by config caller
-	User     string `yaml:"user" toml:"user"`
-	Commands []Cmd  `yaml:"commands" toml:"commands"`
-	OnError  string `yaml:"on_error" toml:"on_error"`
+	Name     string   `yaml:"name" toml:"name"` // name of target, set by config caller
+	User     string   `yaml:"user" toml:"user"`
+	Commands []Cmd    `yaml:"commands" toml:"commands"`
+	OnError  string   `yaml:"on_error" toml:"on_error"`
+	Targets  []string `yaml:"targets" toml:"targets"` // optional list of targets to run task on, names or groups
 }
 
 // Target defines hosts to run commands on


### PR DESCRIPTION
Add new task-level filed `targets`.

It will be used only in case no `-t/--target` is set in the command line. Technically, `-t` always set as it has a default target `default`; however, this PR considers such default as non-set and will use task.targets 

This is what it looks like in the playbook:

```yml
targets:
  prod:
    hosts: [{host: "h1.example.com", user: "test"}, {"h2.example.com", "port": 2222, name: "h2"}]
  staging:
    groups: ["staging"]

tasks:
  - name: task1
    targets: ["dev", "host3.example.com:2222"]
    commands:
      - name: command1
        script: echo "Hello World."
```

targets inside the task resolved the same way as targets defined in the command line, i.e. all the sequence of matching groups, tags, names, etc...

The reason why this may be handy is the ability to make a playbook with multiple tasks where all the tasks are sort of related but should be running on a different subset of hosts. For instance, one task deploys changes to the master/controller boxes, and another task deploys to working nodes.

Before this change, It was possible to run the spot twice for different task with different targets or even different playbooks. However, for related tasks, it is very nice to have a single `spot` run dealing with everything 