### PR TITLE
add a single target field to simplified playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Here are the main differences between the two types of playbooks:
 - The full playbook supports multiple tasks, while the simplified playbook only supports a single task. This means that the full playbook can execute multiple sets of commands, whereas the simplified playbook can only execute one set of commands.
 - The full playbook supports various target types, such as `hosts`, `groups`, and `names`, while the simplified playbook only supports a single type, which is a list of names or host addresses. See the [Targets](#targets) section for more details.
 - The simplified playbook does not support task-level `on_error`, `user`, and `ssh_key` fields, while the full playbook does. See the [Task details](#task-details) section for more information.
+- The simplified playbook also has `target` field (in addition to `targets`) allows to set a single host/name only. This is useful when user want to run the playbook on a single host only. The full playbook does not have this field.
 
 Both types of playbooks support the remaining fields and options.
 

--- a/pkg/config/playbook_test.go
+++ b/pkg/config/playbook_test.go
@@ -133,6 +133,18 @@ func TestPlaybook_New(t *testing.T) {
 			{Host: "127.0.0.1", Port: 2222}}, c.Targets["default"].Hosts)
 	})
 
+	t.Run("simple playbook with a single target set", func(t *testing.T) {
+		c, err := New("testdata/simple-playbook-single-target.yml", nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.Tasks), "1 task")
+		assert.Equal(t, "default", c.Tasks[0].Name, "task name")
+		assert.Equal(t, 5, len(c.Tasks[0].Commands), "5 commands")
+
+		assert.Equal(t, 1, len(c.Targets))
+		assert.Equal(t, 0, len(c.Targets["default"].Names))
+		assert.Equal(t, []Destination{{Host: "127.0.0.1", Port: 2222}}, c.Targets["default"].Hosts)
+	})
+
 	t.Run("playbook with secrets", func(t *testing.T) {
 		secProvider := &mocks.SecretProvider{
 			GetFunc: func(key string) (string, error) {

--- a/pkg/config/testdata/simple-playbook-single-target.yml
+++ b/pkg/config/testdata/simple-playbook-single-target.yml
@@ -1,0 +1,37 @@
+user: app
+ssh_key: ~/.ssh/id_rsa
+
+target: "127.0.0.1:2222"
+
+task:
+  - name: wait
+    script: sleep 5
+
+  - name: copy configuration
+    copy: {"src": "/local/remark42.yml", "dst": "/srv/remark42.yml", "mkdir": true}
+
+  - name: some local command
+    options: {local: true}
+    script: |
+      ls -la /srv
+      du -hcs /srv
+
+  - name: git
+    before: "echo before git"
+    after: "echo after git"
+    onerror: "echo onerror git"
+    script: |
+      git clone https://example.com/remark42.git /srv || true # clone if doesn't exists, but don't fail if exists
+      cd /srv
+      git pull
+
+  - name: docker
+    options: {no_auto: true}
+    script: |
+      docker pull umputun/remark42:latest
+      docker stop remark42 || true
+      docker rm remark42 || true
+      docker run -d --name remark42 -p 8080:8080 umputun/remark42:latest
+    env:
+      FOO: bar
+      BAR: qux


### PR DESCRIPTION
This is a very simple PR adding an extra filed `target` (simplified playbook only). Suitable for cases with a single target so the user won't need to write a list of `targets` with a single host in

Internally it resolved on the low level, as parsing of the simplified playbook was happening. All it does is add this `target` to the list of `targets`. It means the user can even combine both, but I don't see why one would want to do it.

Generally it is a small quality-of-life improvement, nothing major 