### PR TITLE
add cmd option "only_on" allowing to limit on what host

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,14 +315,15 @@ Each command type supports the following options:
 - `no_auto`: if set to `true` the command will not be executed automatically, but can be executed manually using the `--only` flag.
 - `local`: if set to `true` the command will be executed on the local host (the one running the `spot` command) instead of the remote host(s).
 - `sudo`: if set to `true` the command will be executed with `sudo` privileges.
+- `only_on`: optional, allows to set a list of host names or addresses where the command will be executed. If not set, the command will be executed on all hosts.
 
-example setting `ignore_errors` and `no_auto` options:
+example setting `ignore_errors`, `no_auto` and `only_on` options:
 
 ```yaml
   commands:
       - name: wait
         script: sleep 5s
-        options: {ignore_errors: true, no_auto: true}
+        options: {ignore_errors: true, no_auto: true, only_on: [host1, host2]}
 ```
 
 Please note that the `sudo` option is not supported for the `sync` command type, but all other command types support it.

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Each command type supports the following options:
 - `no_auto`: if set to `true` the command will not be executed automatically, but can be executed manually using the `--only` flag.
 - `local`: if set to `true` the command will be executed on the local host (the one running the `spot` command) instead of the remote host(s).
 - `sudo`: if set to `true` the command will be executed with `sudo` privileges.
-- `only_on`: optional, allows to set a list of host names or addresses where the command will be executed. If not set, the command will be executed on all hosts.
+- `only_on`: optional, allows to set a list of host names or addresses where the command will be executed. If not set, the command will be executed on all hosts. For example, `only_on: [host1, host2]` will execute command on `host1` and `host2` only. This option also supports reversed condition, so if user wants to execute command on all hosts except some, `!` prefix can be used. For example, `only_on: [!host1, !host2]` will execute command on all hosts except `host1` and `host2`. 
 
 example setting `ignore_errors`, `no_auto` and `only_on` options:
 

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -30,11 +30,12 @@ type Cmd struct {
 
 // CmdOptions defines options for a command
 type CmdOptions struct {
-	IgnoreErrors bool     `yaml:"ignore_errors" toml:"ignore_errors"`
-	NoAuto       bool     `yaml:"no_auto" toml:"no_auto"`
-	Local        bool     `yaml:"local" toml:"local"`
-	Sudo         bool     `yaml:"sudo" toml:"sudo"`
-	Secrets      []string `yaml:"secrets" toml:"secrets"`
+	IgnoreErrors bool     `yaml:"ignore_errors" toml:"ignore_errors"` // ignore errors and continue
+	NoAuto       bool     `yaml:"no_auto" toml:"no_auto"`             // don't run command automatically
+	Local        bool     `yaml:"local" toml:"local"`                 // run command on localhost
+	Sudo         bool     `yaml:"sudo" toml:"sudo"`                   // run command with sudo
+	Secrets      []string `yaml:"secrets" toml:"secrets"`             // list of secrets (keys) to load
+	OnlyOn       []string `yaml:"only_on" toml:"only_on"`             // only run on these hosts
 }
 
 // CopyInternal defines copy command, implemented internally

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -136,6 +136,10 @@ func (p *Process) runTaskOnHost(ctx context.Context, tsk *config.Task, hostAddr,
 			// skip command if it has NoAuto option and not in Only list
 			continue
 		}
+		if len(cmd.Options.OnlyOn) > 0 && !contains(cmd.Options.OnlyOn, hostName) && !contains(cmd.Options.OnlyOn, hostAddr) {
+			// skip command if it has OnlyOn option and host is not in the list
+			continue
+		}
 
 		infoMsg := fmt.Sprintf("run command %q on host %q (%s)", cmd.Name, hostAddr, hostName)
 		if hostName == "" {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -252,30 +252,17 @@ func (p *Process) shouldRunCmd(onlyOn []string, hostName, hostAddr string) bool 
 		return true
 	}
 
-	isExcluded := func(host string) bool {
-		return strings.HasPrefix(host, "!") &&
-			(hostName == strings.TrimPrefix(host, "!") || hostAddr == strings.TrimPrefix(host, "!"))
-	}
-
-	isIncluded := func(host string) bool {
-		return !strings.HasPrefix(host, "!") && (hostName == host || hostAddr == host)
-	}
-
 	for _, host := range onlyOn {
-		if isExcluded(host) {
-			return false
+		if strings.HasPrefix(host, "!") { // exclude host
+			if hostName == host[1:] || hostAddr == host[1:] {
+				return false
+			}
+			continue
 		}
-		if isIncluded(host) {
+		if hostName == host || hostAddr == host { // include host
 			return true
 		}
 	}
 
-	// Default to running if there were no inclusions.
-	for _, host := range onlyOn {
-		if !strings.HasPrefix(host, "!") {
-			return false
-		}
-	}
-
-	return true
+	return false
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -61,6 +61,38 @@ func TestProcess_Run(t *testing.T) {
 		assert.Equal(t, 1, res.Hosts)
 	})
 
+	t.Run("simple playbook with only_on skip", func(t *testing.T) {
+		conf, err := config.New("testdata/conf-simple.yml", nil, nil)
+		require.NoError(t, err)
+		conf.Tasks[0].Commands[0].Options.OnlyOn = []string{"not-existing-host"}
+		p := Process{
+			Concurrency: 1,
+			Connector:   connector,
+			Config:      conf,
+			ColorWriter: executor.NewColorizedWriter(os.Stdout, "", "", "", nil),
+		}
+		res, err := p.Run(ctx, "default", testingHostAndPort)
+		require.NoError(t, err)
+		assert.Equal(t, 6, res.Commands, "should skip one command")
+		assert.Equal(t, 1, res.Hosts)
+	})
+
+	t.Run("simple playbook with only_on include", func(t *testing.T) {
+		conf, err := config.New("testdata/conf-simple.yml", nil, nil)
+		require.NoError(t, err)
+		conf.Tasks[0].Commands[0].Options.OnlyOn = []string{testingHostAndPort}
+		p := Process{
+			Concurrency: 1,
+			Connector:   connector,
+			Config:      conf,
+			ColorWriter: executor.NewColorizedWriter(os.Stdout, "", "", "", nil),
+		}
+		res, err := p.Run(ctx, "default", testingHostAndPort)
+		require.NoError(t, err)
+		assert.Equal(t, 7, res.Commands, "should include the only_on command")
+		assert.Equal(t, 1, res.Hosts)
+	})
+
 	t.Run("with runtime vars", func(t *testing.T) {
 		conf, err := config.New("testdata/conf.yml", nil, nil)
 		require.NoError(t, err)


### PR DESCRIPTION
This adds a new option to the command allowing limit a particular command to run on a particular host(s). This is somewhat similar to #85 but works on the command level, and limits can be hostname or address. It also allows reverse the condition with `!` prefix, meaning "only on other hosts".

Not something I would often use, as I'd rather make a separate task for such commands, but in some cases can be handy. For example, running a simplified playbook and wanting some command to initialize only one of the destination hosts in a special way