### PR TITLE
Dynamic targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,36 @@ Each task consists of a list of commands that will be executed on the remote hos
 
 - `on_error`: specifies the command to execute on the local host (the one running the `spot` command) in case of an error. The command can use the `{SPOT_ERROR}` variable to access the last error message. Example: `on_error: "curl -s localhost:8080/error?msg={SPOT_ERROR}"`
 - `user`: specifies the SSH user to use when connecting to remote hosts. Overrides the user defined in the top section of playbook file for the specified task.
-- `targets` - list of target names, group, tags or host addresses to execute the task on. Command line `-t` flag can be used to override this field. 
+- `targets` - list of target names, group, tags or host addresses to execute the task on. Command line `-t` flag can be used to override this field. The `targets` field may include variables. For more details see [Dynamic targets](#dynamic-targets) section.
 
 *Note: these fields supported in the full playbook type only*
 
 All tasks are executed sequentially one a given host, one after another. If a task fails, the execution of the playbook will stop and the `on_error` command will be executed on the local host, if defined. Every task has to have `name` field defined, which is used to identify the task everywhere. Playbook with missing `name` field will fail to execute immediately. Duplicate task names are not allowed either.
+
+## Dynamic targets
+
+Spot offers support for dynamic targets, allowing the list of targets to be defined dynamically using variables. This feature becomes particularly useful when users need to ascertain a destination address within one task, and subsequently use it in another task. Here is an illustrative example:
+
+```yaml
+tasks:
+  - name: get host
+    targets: ["default"]
+    script: |
+      export thehost=$(curl -s http://example.com/next-host)
+    options: {local: true}
+    
+  - name: run on host
+    targets: ["$thehost"]
+    script: |
+      echo "doing something on $thehost"
+```
+
+In this example, the host address is initially fetched from http://example.com/next-host. Following this, the task "run on host" is executed on the host that was just identified. This ability to use dynamic targets proves beneficial in a variety of scenarios, especially when the list of hosts is not predetermined.
+
+A practical use case for dynamic targets arises during the provisioning of a new host, followed by the execution of commands on it. Since the IP address of the new host isn't known beforehand, dynamic retrieval becomes essential.
+
+_The reason the first task specifies `targets: ["default"]` is because Spot requires some target to execute a task. In this case, all commands in "get host" tasks are local and won't be invoked on a remote host. The `default` target is utilized by Spot if no alternative target is specified via the command line._
+
 
 ## Relative paths resolution
 

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -102,6 +102,25 @@ func Test_runCompleted(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, time.Since(st) < 1*time.Second)
 	})
+
+	t.Run("run with dynamic targets", func(t *testing.T) {
+		opts := options{
+			SSHUser:      "test",
+			SSHKey:       "testdata/test_ssh_key",
+			PlaybookFile: "testdata/conf-dynamic.yml",
+			SecretsProvider: SecretsProvider{
+				Provider: "spot",
+				Conn:     "testdata/test-secrets.db",
+				Key:      "1234567890",
+			},
+			Env: map[string]string{
+				"hostAndPort": hostAndPort,
+			},
+		}
+		setupLog(true)
+		err := run(opts)
+		require.NoError(t, err)
+	})
 }
 
 func Test_runCompletedSimplePlaybook(t *testing.T) {

--- a/cmd/spot/testdata/conf-dynamic.yml
+++ b/cmd/spot/testdata/conf-dynamic.yml
@@ -1,0 +1,33 @@
+targets:
+  remark42:
+    hosts: [{host: "h1.example.com"}, {host: "h2.example.com"}]
+  staging:
+    inventory_file: {location: "testdata/inventory"}
+
+
+tasks:
+  - name: task1
+    targets: ["default"]
+    commands:
+      - name: some command
+        script: |
+          export host2=$hostAndPort
+          ls -laR /tmp
+          echo "blah" > /tmp/conf.yml
+          cat /tmp/conf.yml
+          echo "all good, 123 - $FOO $BAR"
+        env:
+          FOO: foo-val
+          BAR: bar-val
+        options: {local: true}
+
+
+  - name: task2
+    targets: ["$host2"]
+    commands:
+      - name: good command
+        script: echo good command 1
+      - name: good command
+        script: echo good command 2
+      - name: task vars
+        script: env

--- a/pkg/config/playbook.go
+++ b/pkg/config/playbook.go
@@ -363,6 +363,28 @@ func (p *PlayBook) AllSecretValues() []string {
 	return res
 }
 
+// UpdateTasksTargets updates the targets of all tasks in the playbook with the values from the specified map of variables.
+// The method is used to replace variables in the targets of tasks with their actual values and this way provide dynamic targets.
+func (p *PlayBook) UpdateTasksTargets(vars map[string]string) {
+	for i, task := range p.Tasks {
+		targets := []string{}
+		for _, tg := range task.Targets {
+			if len(tg) > 1 && strings.HasPrefix(tg, "$") {
+				if vars == nil {
+					continue
+				}
+				if v, ok := vars[tg[1:]]; ok {
+					log.Printf("[DEBUG] set target %s to %q", tg, v)
+					targets = append(targets, v)
+				}
+				continue
+			}
+			targets = append(targets, tg)
+		}
+		p.Tasks[i].Targets = targets
+	}
+}
+
 // loadInventory loads the inventory data from the specified location (file or URL) and returns it as an InventoryData struct.
 // The inventory data is parsed as either YAML or TOML, depending on the file extension.
 // The method also performs some additional processing on the inventory data:

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -127,9 +127,11 @@ func (p *Process) runTaskOnHost(ctx context.Context, tsk *config.Task, hostAddr,
 		}
 		defer remote.Close()
 		remote.SetSecrets(p.secrets)
+		report(hostAddr, hostName, "run task %q, commands: %d\n", tsk.Name, len(tsk.Commands))
+	} else {
+		report("localhost", "", "run task %q, commands: %d (local)\n", tsk.Name, len(tsk.Commands))
 	}
 
-	report(hostAddr, hostName, "run task %q, commands: %d\n", tsk.Name, len(tsk.Commands))
 	count := 0
 	tskVars := vars{}
 	for _, cmd := range tsk.Commands {
@@ -159,7 +161,11 @@ func (p *Process) runTaskOnHost(ctx context.Context, tsk *config.Task, hostAddr,
 		}
 	}
 
-	report(hostAddr, hostName, "completed task %q, commands: %d (%v)\n", tsk.Name, count, since(stTask))
+	if p.anyRemoteCommand(tsk) {
+		report(hostAddr, hostName, "completed task %q, commands: %d (%v)\n", tsk.Name, count, since(stTask))
+	} else {
+		report("localhost", "", "completed task %q, commands: %d (%v)\n", tsk.Name, count, since(stTask))
+	}
 	return count, tskVars, nil
 }
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -43,6 +43,7 @@ func TestProcess_Run(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 8, res.Commands)
 		assert.Equal(t, 1, res.Hosts)
+		assert.EqualValues(t, map[string]string{"bar": "9", "baz": "zzzzz", "foo": "6"}, res.Vars)
 	})
 
 	t.Run("simple playbook", func(t *testing.T) {
@@ -167,6 +168,7 @@ func TestProcess_Run(t *testing.T) {
 		assert.Contains(t, outWriter.String(), `> var foo: 6`)
 		assert.Contains(t, outWriter.String(), `> var bar: 9`)
 		assert.Contains(t, outWriter.String(), `> var baz: qux`, "was not overwritten")
+		assert.EqualValues(t, map[string]string{"bar": "9", "baz": "zzzzz", "foo": "6"}, res.Vars)
 	})
 
 	t.Run("with secrets", func(t *testing.T) {
@@ -212,6 +214,7 @@ func TestProcess_Run(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 2, res.Commands)
 		assert.Contains(t, outWriter.String(), ` > setvar filename=testdata/conf.yml`)
+		assert.EqualValues(t, map[string]string{"filename": "testdata/conf.yml"}, res.Vars)
 	})
 
 	t.Run("env variables for copy command", func(t *testing.T) {


### PR DESCRIPTION
This PR adds support for dynamic targets in some limited use cases.

```yaml
tasks:
  - name: get host
    targets: ["default"]
    script: |
      export thehost=$(curl -s http://example.com/next-host)
    options: {local: true}
    
  - name: run on host
    targets: ["$thehost"]
    script: |
      echo "doing something on $thehost"
```

This example indicates the essence of the change. Here the exported variables that are usually available for all the commands in the task will be available for all task targets and `targets: ["$thehost"]` will be evaluated

> A practical use case for dynamic targets arises during the provisioning of a new host, followed by the execution of commands on it. Since the IP address of the new host isn't known beforehand, dynamic retrieval becomes essential.

