### PR TITLE
add condition for script to execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Each command type supports the following options:
 - `local`: if set to `true` the command will be executed on the local host (the one running the `spot` command) instead of the remote host(s).
 - `sudo`: if set to `true` the command will be executed with `sudo` privileges.
 - `only_on`: optional, allows to set a list of host names or addresses where the command will be executed. If not set, the command will be executed on all hosts. For example, `only_on: [host1, host2]` will execute command on `host1` and `host2` only. This option also supports reversed condition, so if user wants to execute command on all hosts except some, `!` prefix can be used. For example, `only_on: [!host1, !host2]` will execute command on all hosts except `host1` and `host2`. 
+- `cond`: defines a condition for the command to be executed. The condition is a valid shell command that will be executed on the remote host(s) and if it returns 0, the primary command will be executed. For example, `cond: "test -f /tmp/foo"` will execute the primary script command only if the file `/tmp/foo` exists. `cond` option supported for `script` command type only.
 
 example setting `ignore_errors`, `no_auto` and `only_on` options:
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -176,22 +176,22 @@ func (p *Process) execCommand(ctx context.Context, ec execCmd) (details string, 
 	switch {
 	case ec.cmd.Script != "":
 		log.Printf("[DEBUG] execute script %q on %s", ec.cmd.Name, ec.hostAddr)
-		return ec.script(ctx)
+		return ec.Script(ctx)
 	case ec.cmd.Copy.Source != "" && ec.cmd.Copy.Dest != "":
 		log.Printf("[DEBUG] copy file to %s", ec.hostAddr)
-		return ec.copy(ctx)
+		return ec.Copy(ctx)
 	case len(ec.cmd.MCopy) > 0:
 		log.Printf("[DEBUG] copy multiple files to %s", ec.hostAddr)
-		return ec.mcopy(ctx)
+		return ec.Mcopy(ctx)
 	case ec.cmd.Sync.Source != "" && ec.cmd.Sync.Dest != "":
 		log.Printf("[DEBUG] sync files on %s", ec.hostAddr)
-		return ec.sync(ctx)
+		return ec.Sync(ctx)
 	case ec.cmd.Delete.Location != "":
 		log.Printf("[DEBUG] delete files on %s", ec.hostAddr)
-		return ec.delete(ctx)
+		return ec.Delete(ctx)
 	case ec.cmd.Wait.Command != "":
 		log.Printf("[DEBUG] wait for command on %s", ec.hostAddr)
-		return ec.wait(ctx)
+		return ec.Wait(ctx)
 	default:
 		return "", nil, fmt.Errorf("unknown command %q", ec.cmd.Name)
 	}


### PR DESCRIPTION
implements #89 

This PR adds a new command field, `cond`. This is an optional condition, which is a single or multiline script. The command will be executed only if the condition script returns 0. If the condition is not set, the command will be executed right away, like before this change.