### PR TITLE
support inverted conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Each command type supports the following options:
 - `local`: if set to `true` the command will be executed on the local host (the one running the `spot` command) instead of the remote host(s).
 - `sudo`: if set to `true` the command will be executed with `sudo` privileges.
 - `only_on`: optional, allows to set a list of host names or addresses where the command will be executed. If not set, the command will be executed on all hosts. For example, `only_on: [host1, host2]` will execute command on `host1` and `host2` only. This option also supports reversed condition, so if user wants to execute command on all hosts except some, `!` prefix can be used. For example, `only_on: [!host1, !host2]` will execute command on all hosts except `host1` and `host2`. 
-- `cond`: defines a condition for the command to be executed. The condition is a valid shell command that will be executed on the remote host(s) and if it returns 0, the primary command will be executed. For example, `cond: "test -f /tmp/foo"` will execute the primary script command only if the file `/tmp/foo` exists. `cond` option supported for `script` command type only.
+- `cond`: defines a condition for the command to be executed. The condition is a valid shell command that will be executed on the remote host(s) and if it returns 0, the primary command will be executed. For example, `cond: "test -f /tmp/foo"` will execute the primary script command only if the file `/tmp/foo` exists. Condition can be inverted by adding `!` prefix, i.e. `! test -f /tmp/foo` will pass only if file `/tmp/foo` doesn't exist. Please note that `cond` option supported for `script` command type only.
 
 example setting `ignore_errors`, `no_auto` and `only_on` options:
 

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -100,19 +100,23 @@ func (cmd *Cmd) GetWait() (command string, rdr io.Reader) {
 }
 
 // GetCondition returns a condition command as a string and an io.Reader based on whether the command is a single line or multiline
-func (cmd *Cmd) GetCondition() (command string, rdr io.Reader) {
+func (cmd *Cmd) GetCondition() (command string, rdr io.Reader, inverted bool) {
 	if cmd.Condition == "" {
-		return "", nil
+		return "", nil, false
 	}
 
-	elems := strings.Split(cmd.Condition, "\n")
+	inverted = strings.HasPrefix(cmd.Condition, "!")
+	cond := strings.TrimPrefix(cmd.Condition, "!")
+	cond = strings.TrimSpace(cond)
+
+	elems := strings.Split(cond, "\n")
 	if len(elems) > 1 {
 		log.Printf("[DEBUG] condition %q is multiline, using script file", cmd.Name)
-		return "", cmd.scriptFile(cmd.Condition)
+		return "", cmd.scriptFile(cond), inverted
 	}
 
 	log.Printf("[DEBUG] condition %q is single line, using condition string", cmd.Name)
-	return cmd.scriptCommand(cmd.Condition), nil
+	return cmd.scriptCommand(cond), nil, inverted
 }
 
 // scriptCommand concatenates all script lines in commands into one a string to be executed by shell.

--- a/pkg/runner/commands_test.go
+++ b/pkg/runner/commands_test.go
@@ -273,4 +273,14 @@ func Test_execCmd(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, " {script: sh -c 'echo condition true'}", details)
 	})
+
+	t.Run("condition true inverted", func(t *testing.T) {
+		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", true)
+		require.NoError(t, err)
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Condition: "! ls -la /srv/test.condition",
+			Script: "echo condition true", Name: "test"}}
+		details, _, err := ec.Script(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, " {skip: test}", details)
+	})
 }


### PR DESCRIPTION
This simple change allows us to invert conditions (see #93) by adding `!` prefix.