### PR TITLE
Echo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Spot supports the following command types:
 - `sync`: syncs directory from the local machine to the remote host(s). Optionally supports deleting files on the remote host(s) that don't exist locally. Example: `sync: {"src": "testdata", "dst": "/tmp/things", "delete": true}`
 - `delete`: deletes a file or directory on the remote host(s), optionally can remove recursively. Example: `delete: {"path": "/tmp/things", "recur": true}`
 - `wait`: waits for the specified command to finish on the remote host(s) with 0 error code. This command is useful when you need to wait for a service to start before executing the next command. Allows to specify the timeout as well as check interval. Example: `wait: {"cmd": "curl -s --fail localhost:8080", "timeout": "30s", "interval": "1s"}`
+- `echo`: prints the specified message to the console. Example: `echo: "Hello World $some_var"`. This command is useful for debugging purposes and also to print the value of variables to the console.
 
 ### Command options
 

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -22,6 +22,7 @@ type Cmd struct {
 	Delete      DeleteInternal    `yaml:"delete" toml:"delete"`
 	Wait        WaitInternal      `yaml:"wait" toml:"wait"`
 	Script      string            `yaml:"script" toml:"script,multiline"`
+	Echo        string            `yaml:"echo" toml:"echo"`
 	Environment map[string]string `yaml:"env" toml:"env"`
 	Options     CmdOptions        `yaml:"options" toml:"options,omitempty"`
 	Condition   string            `yaml:"cond" toml:"cond,omitempty"`
@@ -330,6 +331,7 @@ func (cmd *Cmd) validate() error {
 		{"delete", func() bool { return cmd.Delete.Location != "" }},
 		{"sync", func() bool { return cmd.Sync.Source != "" && cmd.Sync.Dest != "" }},
 		{"wait", func() bool { return cmd.Wait.Command != "" }},
+		{"echo", func() bool { return cmd.Echo != "" }},
 	}
 
 	setCmds, names := []string{}, []string{}

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -415,7 +415,7 @@ func TestCmd_validate(t *testing.T) {
 		{"only wait", Cmd{Wait: WaitInternal{Command: "command"}}, ""},
 		{"multiple fields set", Cmd{Script: "example_script", Copy: CopyInternal{Source: "source", Dest: "dest"}},
 			"only one of [script, copy] is allowed"},
-		{"nothing set", Cmd{}, "one of [script, copy, mcopy, delete, sync, wait] must be set"},
+		{"nothing set", Cmd{}, "one of [script, copy, mcopy, delete, sync, wait, echo] must be set"},
 	}
 
 	for _, tt := range tbl {

--- a/pkg/runner/commands.go
+++ b/pkg/runner/commands.go
@@ -244,6 +244,25 @@ func (ec *execCmd) Wait(ctx context.Context) (details string, vars map[string]st
 	}
 }
 
+// Echo prints a message. It enforces the echo command to start with "echo " and adds sudo if needed.
+// It returns the result of the echo command as details string.
+func (ec *execCmd) Echo(ctx context.Context) (string, map[string]string, error) {
+	tmpl := templater{hostAddr: ec.hostAddr, hostName: ec.hostName, task: ec.tsk, command: ec.cmd.Name, env: ec.cmd.Environment}
+	echoCmd := tmpl.apply(ec.cmd.Echo)
+	if !strings.HasPrefix(echoCmd, "echo ") {
+		echoCmd = fmt.Sprintf("echo %s", echoCmd)
+	}
+	if ec.cmd.Options.Sudo {
+		echoCmd = fmt.Sprintf("sudo %s", echoCmd)
+	}
+	out, err := ec.exec.Run(ctx, echoCmd, false)
+	if err != nil {
+		return "", nil, fmt.Errorf("can't run echo command on %s: %w", ec.hostAddr, err)
+	}
+	details := fmt.Sprintf(" {echo: %s}", strings.Join(out, "; "))
+	return details, nil, nil
+}
+
 func (ec *execCmd) checkCondition(ctx context.Context) (bool, error) {
 	if ec.cmd.Condition == "" {
 		return true, nil // no condition, always allow

--- a/pkg/runner/commands.go
+++ b/pkg/runner/commands.go
@@ -246,7 +246,7 @@ func (ec *execCmd) Wait(ctx context.Context) (details string, vars map[string]st
 
 // Echo prints a message. It enforces the echo command to start with "echo " and adds sudo if needed.
 // It returns the result of the echo command as details string.
-func (ec *execCmd) Echo(ctx context.Context) (string, map[string]string, error) {
+func (ec *execCmd) Echo(ctx context.Context) (details string, vars map[string]string, err error) {
 	tmpl := templater{hostAddr: ec.hostAddr, hostName: ec.hostName, task: ec.tsk, command: ec.cmd.Name, env: ec.cmd.Environment}
 	echoCmd := tmpl.apply(ec.cmd.Echo)
 	if !strings.HasPrefix(echoCmd, "echo ") {
@@ -259,7 +259,7 @@ func (ec *execCmd) Echo(ctx context.Context) (string, map[string]string, error) 
 	if err != nil {
 		return "", nil, fmt.Errorf("can't run echo command on %s: %w", ec.hostAddr, err)
 	}
-	details := fmt.Sprintf(" {echo: %s}", strings.Join(out, "; "))
+	details = fmt.Sprintf(" {echo: %s}", strings.Join(out, "; "))
 	return details, nil, nil
 }
 

--- a/pkg/runner/commands_test.go
+++ b/pkg/runner/commands_test.go
@@ -283,4 +283,21 @@ func Test_execCmd(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, " {skip: test}", details)
 	})
+
+	t.Run("echo command", func(t *testing.T) {
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Echo: "welcome back", Name: "test"}}
+		details, _, err := ec.Echo(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, " {echo: welcome back}", details)
+
+		ec = execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Echo: "echo welcome back", Name: "test"}}
+		details, _, err = ec.Echo(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, " {echo: welcome back}", details)
+
+		ec = execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Echo: "$var1 welcome back", Name: "test", Environment: map[string]string{"var1": "foo"}}}
+		details, _, err = ec.Echo(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, " {echo: foo welcome back}", details)
+	})
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -192,6 +192,9 @@ func (p *Process) execCommand(ctx context.Context, ec execCmd) (details string, 
 	case ec.cmd.Wait.Command != "":
 		log.Printf("[DEBUG] wait for command on %s", ec.hostAddr)
 		return ec.Wait(ctx)
+	case ec.cmd.Echo != "":
+		log.Printf("[DEBUG] echo on %s", ec.hostAddr)
+		return ec.Echo(ctx)
 	default:
 		return "", nil, fmt.Errorf("unknown command %q", ec.cmd.Name)
 	}

--- a/pkg/runner/testdata/conf.yml
+++ b/pkg/runner/testdata/conf.yml
@@ -99,6 +99,10 @@ tasks:
         copy: {src: "${filename}", dst: "/srv/conf.yml"}
         options: {no_auto: true, sudo: true}
 
+      - name: echo things
+        echo: vars - $foo, $bar, $baz
+        options: {no_auto: true}
+
   - name: failed_task
     commands:
       - name: good command


### PR DESCRIPTION
This is a new command, `echo`. The only goal is to print something to the normal (i.e. non- verbose and non-debug) log. This command is a little bit redundant; currently, it is possible to do just `echo` in a script and see the output in `-v` mode. However, there are use cases where such output is an essential result from the playbook execution, for example, if the playbook made a new resource, like an instance or volume and we need to inform the user what is ip/id of the new resource. For cases like this, I don't want to hide this info behind `-v` flag.

The echo command is `echo` and it is the lowest priority match, i.e. all the existing command will match first before we try to recognize `echo`. In the playbook, this command is as simple as this:

```yaml
- name: show things
   echo: something blah $foo $bar
```

_the command is not just printing things directly, it actually runs `sh -c echo ....` on the target (or local) host._