### PR TITLE
support multiple delete commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,11 +326,20 @@ This approach is intentional to prevent confusion and make it easier to comprehe
 Spot supports the following command types:
 
 - `script`: can be any valid shell script. The script will be executed on the remote host(s) using SSH, inside a shell.
-- `copy`: copies a file from the local machine to the remote host(s). Example: `copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}`. If `mkdir` is set to `true` the command will create the destination directory if it doesn't exist, same as `mkdir -p` in bash. Note: `copy` command type supports multiple commands too presented as a list of copy elements.
-- `sync`: syncs directory from the local machine to the remote host(s). Optionally supports deleting files on the remote host(s) that don't exist locally. Example: `sync: {"src": "testdata", "dst": "/tmp/things", "delete": true}`. Another option is `exclude` which allows to specify a list of files to exclude from the sync. Example: `sync: {"src": "testdata", "dst": "/tmp/things", "exclude": ["*.txt", "*.yml"]}`. Note: `sync` command type supports multiple commands too presented as a list of sync elements.
+- `copy`: copies a file from the local machine to the remote host(s). Example: `copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}`. If `mkdir` is set to `true` the command will create the destination directory if it doesn't exist, same as `mkdir -p` in bash.
+- `sync`: syncs directory from the local machine to the remote host(s). Optionally supports deleting files on the remote host(s) that don't exist locally. Example: `sync: {"src": "testdata", "dst": "/tmp/things", "delete": true}`. Another option is `exclude` which allows to specify a list of files to exclude from the sync. Example: `sync: {"src": "testdata", "dst": "/tmp/things", "exclude": ["*.txt", "*.yml"]}`.
 - `delete`: deletes a file or directory on the remote host(s), optionally can remove recursively. Example: `delete: {"path": "/tmp/things", "recur": true}`
 - `wait`: waits for the specified command to finish on the remote host(s) with 0 error code. This command is useful when you need to wait for a service to start before executing the next command. Allows to specify the timeout as well as check interval. Example: `wait: {"cmd": "curl -s --fail localhost:8080", "timeout": "30s", "interval": "1s"}`
 - `echo`: prints the specified message to the console. Example: `echo: "Hello World $some_var"`. This command is useful for debugging purposes and also to print the value of variables to the console.
+
+Note: `copy`, `sync`, and `delete` commands support lists the list form as well, so multiple files/paths can be copied, synced or deleted in one command. For example:
+
+```yml
+copy: 
+  - {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml"}, 
+  - {"src": "testdata/conf2.yml", "dst": "/tmp/conf2.yml"}
+  - {"src": "testdata/etc/*", "dst": "/tmp/etc", "mkdir": true}
+```
 
 ### Command options
 

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -427,7 +427,7 @@ func TestCmd_validate(t *testing.T) {
 		{"only wait", Cmd{Wait: WaitInternal{Command: "command"}}, ""},
 		{"multiple fields set", Cmd{Script: "example_script", Copy: CopyInternal{Source: "source", Dest: "dest"}},
 			"only one of [script, copy] is allowed"},
-		{"nothing set", Cmd{}, "one of [script, copy, mcopy, delete, sync, msync, wait, echo] must be set"},
+		{"nothing set", Cmd{}, "one of [script, copy, mcopy, delete, mdelete, sync, msync, wait, echo] must be set"},
 	}
 
 	for _, tt := range tbl {

--- a/pkg/runner/commands_test.go
+++ b/pkg/runner/commands_test.go
@@ -202,6 +202,21 @@ func Test_execCmd(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("delete a multi-files", func(t *testing.T) {
+		_, err := sess.Run(ctx, "touch /tmp/delete1.me /tmp/delete2.me ", true)
+		require.NoError(t, err)
+		_, err = sess.Run(ctx, "ls /tmp/delete1.me", true)
+		require.NoError(t, err)
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{MDelete: []config.DeleteInternal{
+			{Location: "/tmp/delete1.me"}, {Location: "/tmp/delete2.me"}}}}
+		_, _, err = ec.MDelete(ctx)
+		require.NoError(t, err)
+		_, err = sess.Run(ctx, "ls /tmp/delete1.me", true)
+		require.Error(t, err)
+		_, err = sess.Run(ctx, "ls /tmp/delete2.me", true)
+		require.Error(t, err)
+	})
+
 	t.Run("delete files recursive", func(t *testing.T) {
 		var err error
 		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-recursive", true)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -192,6 +192,9 @@ func (p *Process) execCommand(ctx context.Context, ec execCmd) (details string, 
 	case ec.cmd.Delete.Location != "":
 		log.Printf("[DEBUG] delete files on %s", ec.hostAddr)
 		return ec.Delete(ctx)
+	case len(ec.cmd.MDelete) > 0:
+		log.Printf("[DEBUG] delete multiple files on %s", ec.hostAddr)
+		return ec.MDelete(ctx)
 	case ec.cmd.Wait.Command != "":
 		log.Printf("[DEBUG] wait for command on %s", ec.hostAddr)
 		return ec.Wait(ctx)

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -263,6 +263,30 @@ func TestProcess_Run(t *testing.T) {
 		assert.Equal(t, 3, res.Commands)
 		assert.Contains(t, outWriter.String(), `completed command "echo things" {echo: vars - 6, 9, zzzzz}`)
 	})
+
+	t.Run("delete multiple files", func(t *testing.T) {
+		conf, err := config.New("testdata/conf.yml", nil, nil)
+		require.NoError(t, err)
+
+		p := Process{
+			Concurrency: 1,
+			Connector:   connector,
+			Config:      conf,
+			ColorWriter: executor.NewColorizedWriter(os.Stdout, "", "", "", nil),
+			Only:        []string{"prep multiple files for delete", "delete multiple files"},
+		}
+
+		outWriter := &bytes.Buffer{}
+		log.SetOutput(io.MultiWriter(outWriter, os.Stderr))
+
+		res, err := p.Run(ctx, "task1", testingHostAndPort)
+		require.NoError(t, err)
+		assert.Equal(t, 2, res.Commands)
+		assert.Equal(t, 1, res.Hosts)
+		assert.Contains(t, outWriter.String(), `deleted /tmp/deleteme.1`)
+		assert.Contains(t, outWriter.String(), `deleted /tmp/deleteme.2`)
+	})
+
 }
 
 func TestProcess_RunWithSudo(t *testing.T) {

--- a/pkg/runner/testdata/conf.yml
+++ b/pkg/runner/testdata/conf.yml
@@ -103,6 +103,19 @@ tasks:
         echo: vars - $foo, $bar, $baz
         options: {no_auto: true}
 
+      - name: prep multiple files for delete
+        copy:
+          - {src: testdata/conf.yml, dst: /tmp/deleteme.1}
+          - {src: testdata/conf.yml, dst: /tmp/deleteme.2}
+        options: {no_auto: true}
+      - name: delete multiple files
+        delete:
+          - {path: "/tmp/deleteme.1"}
+          - {path: "/tmp/deleteme.2"}
+        options: {no_auto: true}
+
+
+
   - name: failed_task
     commands:
       - name: good command


### PR DESCRIPTION
similar to #99 but for delete command

after the change delete can be a list of paths, i.e.

```yml
delete:
  - {path: /srv/foo}
  - {path: /srv/bar}
```

_The command keeps the single form untouched_ 