### PR TITLE
Copy with check and force mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,12 +330,19 @@ script: |
 
 Copies a file from the local machine to the remote host(s). If `mkdir` is set to `true` the command will create the destination directory if it doesn't exist, same as `mkdir -p` in bash. The command also supports glob patterns in `src` field.
 
+Copy command performs a quick check to see if the file already exists on the remote host(s) with the same size and modification time,
+and skips the copy if it does. This option can be disabled by setting `force: true` flag.
+
 ```yaml
 - name: copy file with mkdir
   copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf.yml", "mkdir": true}`
 
 - name: copy files with glob
   copy: {"src": "testdata/*.csv", "dst": "/tmp/things"}`
+
+
+- name: copy files with force flag
+  copy: {"src": "testdata/*.csv", "dst": "/tmp/things", "force": true}`
 ```
 
 Copy also supports list format to copy multiple files at once:

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -44,17 +44,19 @@ type CmdOptions struct {
 
 // CopyInternal defines copy command, implemented internally
 type CopyInternal struct {
-	Source string `yaml:"src" toml:"src"`
-	Dest   string `yaml:"dst" toml:"dst"`
-	Mkdir  bool   `yaml:"mkdir" toml:"mkdir"`
+	Source string `yaml:"src" toml:"src"`     // source must be a file or a glob pattern
+	Dest   string `yaml:"dst" toml:"dst"`     // destination must be a file or a directory
+	Mkdir  bool   `yaml:"mkdir" toml:"mkdir"` // create destination directory if it does not exist
+	Force  bool   `yaml:"force" toml:"force"` // force copy even if source and destination are the same
 }
 
 // SyncInternal defines sync command (recursive copy), implemented internally
 type SyncInternal struct {
-	Source  string   `yaml:"src" toml:"src"`
-	Dest    string   `yaml:"dst" toml:"dst"`
-	Delete  bool     `yaml:"delete" toml:"delete"`
-	Exclude []string `yaml:"exclude" toml:"exclude"`
+	Source  string   `yaml:"src" toml:"src"`         // source must be a directory
+	Dest    string   `yaml:"dst" toml:"dst"`         // destination must be a directory
+	Delete  bool     `yaml:"delete" toml:"delete"`   // delete files in destination that are not in source
+	Exclude []string `yaml:"exclude" toml:"exclude"` // exclude files matching these patterns
+	Force   bool     `yaml:"force" toml:"force"`     // force sync even if source and destination are the same
 }
 
 // DeleteInternal defines delete command, implemented internally

--- a/pkg/executor/dry.go
+++ b/pkg/executor/dry.go
@@ -29,9 +29,9 @@ func (ex *Dry) SetSecrets(secrets []string) {
 }
 
 // Run shows the command content, doesn't execute it
-func (ex *Dry) Run(_ context.Context, cmd string, verbose bool) (out []string, err error) {
+func (ex *Dry) Run(_ context.Context, cmd string, opts *RunOpts) (out []string, err error) {
 	log.Printf("[DEBUG] run %s", cmd)
-	outLog, _ := MakeOutAndErrWriters(ex.hostAddr, ex.hostName, verbose, ex.secrets)
+	outLog, _ := MakeOutAndErrWriters(ex.hostAddr, ex.hostName, opts != nil && opts.Verbose, ex.secrets)
 	var stdoutBuf bytes.Buffer
 	mwr := io.MultiWriter(outLog, &stdoutBuf)
 	mwr.Write([]byte(cmd)) //nolint
@@ -44,7 +44,8 @@ func (ex *Dry) Run(_ context.Context, cmd string, verbose bool) (out []string, e
 }
 
 // Upload doesn't actually upload, just prints the command
-func (ex *Dry) Upload(_ context.Context, local, remote string, mkdir bool) (err error) {
+func (ex *Dry) Upload(_ context.Context, local, remote string, opts *UpDownOpts) (err error) {
+	mkdir := opts != nil && opts.Mkdir
 	log.Printf("[DEBUG] upload %s to %s, mkdir: %v", local, remote, mkdir)
 	if strings.Contains(remote, "spot-script") {
 		// this is a temp script created by spot to perform script execution on remote host
@@ -69,19 +70,26 @@ func (ex *Dry) Upload(_ context.Context, local, remote string, mkdir bool) (err 
 }
 
 // Download file from remote server with scp
-func (ex *Dry) Download(_ context.Context, remote, local string, mkdir bool) (err error) {
+func (ex *Dry) Download(_ context.Context, remote, local string, opts *UpDownOpts) (err error) {
+	mkdir := opts != nil && opts.Mkdir
 	log.Printf("[DEBUG] download %s to %s, mkdir: %v", local, remote, mkdir)
 	return nil
 }
 
 // Sync doesn't sync anything, just prints the command
-func (ex *Dry) Sync(_ context.Context, localDir, remoteDir string, del bool, exclude []string) ([]string, error) {
-	log.Printf("[DEBUG] sync %s to %s, delite: %v, exlcude: %v", localDir, remoteDir, del, exclude) //nolint
+func (ex *Dry) Sync(_ context.Context, localDir, remoteDir string, opts *SyncOpts) ([]string, error) {
+	del := opts != nil && opts.Delete
+	exclude := []string{}
+	if opts != nil {
+		exclude = opts.Exclude
+	}
+	log.Printf("[DEBUG] sync %s to %s, delete: %v, exlcude: %v", localDir, remoteDir, del, exclude) //nolint
 	return nil, nil
 }
 
 // Delete doesn't delete anything, just prints the command
-func (ex *Dry) Delete(_ context.Context, remoteFile string, recursive bool) (err error) {
+func (ex *Dry) Delete(_ context.Context, remoteFile string, opts *DeleteOpts) (err error) {
+	recursive := opts != nil && opts.Recursive
 	log.Printf("[DEBUG] delete %s, recursive: %v", remoteFile, recursive)
 	return nil
 }

--- a/pkg/executor/dry_test.go
+++ b/pkg/executor/dry_test.go
@@ -15,7 +15,7 @@ import (
 func TestDry_Run(t *testing.T) {
 	ctx := context.Background()
 	dry := NewDry("hostAddr", "hostName")
-	res, err := dry.Run(ctx, "ls -la /srv", true)
+	res, err := dry.Run(ctx, "ls -la /srv", &RunOpts{Verbose: true})
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	require.Equal(t, "ls -la /srv", res[0])
@@ -37,7 +37,7 @@ func TestDryUpload(t *testing.T) {
 	}
 
 	stdout := captureOutput(func() {
-		err = dry.Upload(context.Background(), tempFile.Name(), "remote/path/spot-script", true)
+		err = dry.Upload(context.Background(), tempFile.Name(), "remote/path/spot-script", &UpDownOpts{Mkdir: true})
 	})
 
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestDryUpload_FileOpenError(t *testing.T) {
 		hostName: "host1",
 	}
 
-	err := dry.Upload(context.Background(), nonExistentFile, "remote/path/spot-script", true)
+	err := dry.Upload(context.Background(), nonExistentFile, "remote/path/spot-script", &UpDownOpts{Mkdir: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "open non_existent_file", "expected error message containing 'open non_existent_file' not found")
 }
@@ -77,22 +77,22 @@ func TestDryOperations(t *testing.T) {
 		{
 			name: "download",
 			operation: func() error {
-				return dry.Download(context.Background(), "remote/path", "local/path", true)
+				return dry.Download(context.Background(), "remote/path", "local/path", &UpDownOpts{Mkdir: true})
 			},
 			expectedLog: "[DEBUG] download local/path to remote/path, mkdir: true",
 		},
 		{
 			name: "sync",
 			operation: func() error {
-				_, err := dry.Sync(context.Background(), "local/dir", "remote/dir", true, nil)
+				_, err := dry.Sync(context.Background(), "local/dir", "remote/dir", &SyncOpts{Delete: true})
 				return err
 			},
-			expectedLog: "[DEBUG] sync local/dir to remote/dir, delite: true",
+			expectedLog: "[DEBUG] sync local/dir to remote/dir, delete: true",
 		},
 		{
 			name: "delete",
 			operation: func() error {
-				return dry.Delete(context.Background(), "remote/file", true)
+				return dry.Delete(context.Background(), "remote/file", &DeleteOpts{Recursive: true})
 			},
 			expectedLog: "[DEBUG] delete remote/file, recursive: true",
 		},

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -21,12 +21,37 @@ import (
 // Implemented by Remote and Local structs.
 type Interface interface {
 	SetSecrets(secrets []string)
-	Run(ctx context.Context, c string, verbose bool) (out []string, err error)
-	Upload(ctx context.Context, local, remote string, mkdir bool) (err error)
-	Download(ctx context.Context, remote, local string, mkdir bool) (err error)
-	Sync(ctx context.Context, localDir, remoteDir string, del bool, exclude []string) ([]string, error)
-	Delete(ctx context.Context, remoteFile string, recursive bool) (err error)
+	Run(ctx context.Context, c string, opts *RunOpts) (out []string, err error)
+	Upload(ctx context.Context, local, remote string, opts *UpDownOpts) (err error)
+	Download(ctx context.Context, remote, local string, opts *UpDownOpts) (err error)
+	Sync(ctx context.Context, localDir, remoteDir string, opts *SyncOpts) ([]string, error)
+	Delete(ctx context.Context, remoteFile string, opts *DeleteOpts) (err error)
 	Close() error
+}
+
+// RunOpts is a struct for run options.
+type RunOpts struct {
+	Verbose bool // print more info to primary stdout
+}
+
+// UpDownOpts is a struct for upload and download options.
+type UpDownOpts struct {
+	Mkdir    bool // create remote directory if it does not exist
+	Checksum bool // compare checksums of local and remote files, default is size and modtime
+	Force    bool // overwrite existing files on remote
+}
+
+// SyncOpts is a struct for sync options.
+type SyncOpts struct {
+	Delete   bool     // delete extra files on remote
+	Exclude  []string // exclude files matching the given patterns
+	Checksum bool     // compare checksums of local and remote files, default is size and modtime
+	Force    bool     // overwrite existing files on remote
+}
+
+// DeleteOpts is a struct for delete options.
+type DeleteOpts struct {
+	Recursive bool // delete directories recursively
 }
 
 // StdOutLogWriter is a writer that writes to log with a prefix and a log level.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 )
@@ -181,4 +182,12 @@ func isExcluded(path string, excl []string) bool {
 		}
 	}
 	return false
+}
+
+func isWithinOneSecond(t1, t2 time.Time) bool {
+	diff := t1.Sub(t2)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= time.Second
 }

--- a/pkg/runner/commands_test.go
+++ b/pkg/runner/commands_test.go
@@ -146,7 +146,7 @@ func Test_execCmd(t *testing.T) {
 
 	t.Run("wait done", func(t *testing.T) {
 		time.AfterFunc(time.Second, func() {
-			_, _ = sess.Run(ctx, "touch /tmp/wait.done", false)
+			_, _ = sess.Run(ctx, "touch /tmp/wait.done", nil)
 		})
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Wait: config.WaitInternal{
 			Command: "cat /tmp/wait.done", Timeout: 2 * time.Second, CheckDuration: time.Millisecond * 100}}}
@@ -157,7 +157,7 @@ func Test_execCmd(t *testing.T) {
 
 	t.Run("wait multiline done", func(t *testing.T) {
 		time.AfterFunc(time.Second, func() {
-			_, _ = sess.Run(ctx, "touch /tmp/wait.done", false)
+			_, _ = sess.Run(ctx, "touch /tmp/wait.done", nil)
 		})
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Wait: config.WaitInternal{
 			Command: "echo this is wait\ncat /tmp/wait.done", Timeout: 2 * time.Second, CheckDuration: time.Millisecond * 100}}}
@@ -168,7 +168,7 @@ func Test_execCmd(t *testing.T) {
 
 	t.Run("wait done with sudo", func(t *testing.T) {
 		time.AfterFunc(time.Second, func() {
-			_, _ = sess.Run(ctx, "sudo touch /srv/wait.done", false)
+			_, _ = sess.Run(ctx, "sudo touch /srv/wait.done", nil)
 		})
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Wait: config.WaitInternal{
 			Command: "cat /srv/wait.done", Timeout: 2 * time.Second, CheckDuration: time.Millisecond * 100},
@@ -194,7 +194,7 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("delete a single file", func(t *testing.T) {
-		_, err := sess.Run(ctx, "touch /tmp/delete.me", true)
+		_, err := sess.Run(ctx, "touch /tmp/delete.me", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
 			Location: "/tmp/delete.me"}}}
@@ -203,27 +203,27 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("delete a multi-files", func(t *testing.T) {
-		_, err := sess.Run(ctx, "touch /tmp/delete1.me /tmp/delete2.me ", true)
+		_, err := sess.Run(ctx, "touch /tmp/delete1.me /tmp/delete2.me ", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "ls /tmp/delete1.me", true)
+		_, err = sess.Run(ctx, "ls /tmp/delete1.me", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{MDelete: []config.DeleteInternal{
 			{Location: "/tmp/delete1.me"}, {Location: "/tmp/delete2.me"}}}}
 		_, _, err = ec.MDelete(ctx)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "ls /tmp/delete1.me", true)
+		_, err = sess.Run(ctx, "ls /tmp/delete1.me", &executor.RunOpts{Verbose: true})
 		require.Error(t, err)
-		_, err = sess.Run(ctx, "ls /tmp/delete2.me", true)
+		_, err = sess.Run(ctx, "ls /tmp/delete2.me", &executor.RunOpts{Verbose: true})
 		require.Error(t, err)
 	})
 
 	t.Run("delete files recursive", func(t *testing.T) {
 		var err error
-		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-recursive", true)
+		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-recursive", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "touch /tmp/delete-recursive/delete1.me", true)
+		_, err = sess.Run(ctx, "touch /tmp/delete-recursive/delete1.me", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "touch /tmp/delete-recursive/delete2.me", true)
+		_, err = sess.Run(ctx, "touch /tmp/delete-recursive/delete2.me", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
 
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
@@ -232,12 +232,12 @@ func Test_execCmd(t *testing.T) {
 		_, _, err = ec.Delete(ctx)
 		require.NoError(t, err)
 
-		_, err = sess.Run(ctx, "ls /tmp/delete-recursive", true)
+		_, err = sess.Run(ctx, "ls /tmp/delete-recursive", &executor.RunOpts{Verbose: true})
 		require.Error(t, err, "should not exist")
 	})
 
 	t.Run("delete file with sudo", func(t *testing.T) {
-		_, err := sess.Run(ctx, "sudo touch /srv/delete.me", true)
+		_, err := sess.Run(ctx, "sudo touch /srv/delete.me", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
 			Location: "/srv/delete.me"}, Options: config.CmdOptions{Sudo: false}}}
@@ -254,11 +254,11 @@ func Test_execCmd(t *testing.T) {
 
 	t.Run("delete files recursive with sudo", func(t *testing.T) {
 		var err error
-		_, err = sess.Run(ctx, "sudo mkdir -p /srv/delete-recursive", true)
+		_, err = sess.Run(ctx, "sudo mkdir -p /srv/delete-recursive", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "sudo touch /srv/delete-recursive/delete1.me", true)
+		_, err = sess.Run(ctx, "sudo touch /srv/delete-recursive/delete1.me", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "sudo touch /srv/delete-recursive/delete2.me", true)
+		_, err = sess.Run(ctx, "sudo touch /srv/delete-recursive/delete2.me", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
 
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
@@ -267,7 +267,7 @@ func Test_execCmd(t *testing.T) {
 		_, _, err = ec.Delete(ctx)
 		require.NoError(t, err)
 
-		_, err = sess.Run(ctx, "ls /srv/delete-recursive", true)
+		_, err = sess.Run(ctx, "ls /srv/delete-recursive", &executor.RunOpts{Verbose: true})
 		require.Error(t, err, "should not exist")
 	})
 
@@ -280,7 +280,7 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("condition true", func(t *testing.T) {
-		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", true)
+		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Condition: "ls -la /srv/test.condition",
 			Script: "echo condition true", Name: "test"}}
@@ -290,7 +290,7 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("condition true inverted", func(t *testing.T) {
-		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", true)
+		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", &executor.RunOpts{Verbose: true})
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Condition: "! ls -la /srv/test.condition",
 			Script: "echo condition true", Name: "test"}}


### PR DESCRIPTION
This PR partially addresses #77 for the `copy` command. It adds the same default behavior `sync` already had i.e. skipping the copy operation in case the destination file is identical to the source file.

The check works the same way as rsync's default "quick check" and compares file sizes and modification time. Adding checksum support will be done too, some day. 

The check can be suppressed by `force` option