### PR TITLE
allow script to have shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,18 @@ echo "All done! $FOO $BAR"
 
 By using this approach, Spot enables users to write and execute more complex scripts, providing greater flexibility and power in managing remote hosts or local environments.
 
+User can also set any custom shebang for the script by adding `#!` at the beginning of the script. For example:
+
+```yaml
+commands:
+  - name: multi_line_script
+    script: |
+      #!/bin/bash
+      touch /tmp/file1
+      echo "Hello World" > /tmp/file2
+
+```
+
 ### Passing variables from one script command to another
 
 Spot allows to pass variables from one command to another. This feature is especially useful when a command, often a script, sets a variable, and the subsequent command requires this variable. For instance, if one command creates a file and the file name is needed in another command. To pass these variables, user must use the conventional shell's export directive in the initial script command. Subsequently, all variables exported in this initial command will be accessible in the following commands.

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -211,6 +211,13 @@ func TestCmd_getScriptFile(t *testing.T) {
 			expected: "#!/bin/sh\nset -e\necho 'Hello, World!'\n",
 		},
 		{
+			name: "with custom shebang",
+			cmd: &Cmd{
+				Script: "#!/bin/bash\necho 'Hello, World!'",
+			},
+			expected: "#!/bin/bash\nset -e\necho 'Hello, World!'\n",
+		},
+		{
 			name: "with one environment variable",
 			cmd: &Cmd{
 				Script: "echo 'Hello, World!'",
@@ -573,6 +580,27 @@ echo 'Goodbye, World!'
 			} else {
 				assert.Nil(t, reader)
 			}
+		})
+	}
+}
+
+func TestHasShebang(t *testing.T) {
+	testCases := []struct {
+		name string
+		inp  string
+		exp  bool
+	}{
+		{"empty string", "", false},
+		{"no newline", "test data", false},
+		{"newline, no shebang", "test\ndata", false},
+		{"newline, shebang not at start", "test\n# data", false},
+		{"newline, shebang at start", "#!test\ndata", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &Cmd{} // Assuming Cmd is your type with hasShebang method
+			require.Equal(t, tc.exp, cmd.hasShebang(tc.inp))
 		})
 	}
 }


### PR DESCRIPTION
This is related to https://github.com/umputun/spot/discussions/116#discussioncomment-6087380

The change allows to set of any custom shebang (i.e. `#!/bin/bash`) to define the shell running the script