### PR TITLE
Support env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ commands:
 
 Environment variables can be set with `--env` / `-e` cli option. For example: `-e VAR1:VALUE1 -e VAR2:VALUE2`. Environment variables can also be set in the environment file (default `env.yml` can be changed with `--env-file` / `-E` cli flag). For example:
 ```yaml
-env:  
+vars:  
   VAR1: VALUE1
   VAR2: VALUE2
 ```

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Spot supports the following command-line options:
 - `-s`, `--skip=`: Skips the specified commands during the task execution. Providing the `-s` flag multiple times with different command names skips multiple commands.
 - `-o`, `--only=`: Runs only the specified commands during the task execution. Providing the `-o` flag multiple times with different command names runs only multiple commands.
 - `-e`, `--env=`: Sets the environment variables to be used during the task execution. Providing the `-e` flag multiple times with different environment variables sets multiple environment variables, e.g., `-e VAR1:VALUE1 -e VAR2:VALUE2`.
+- `-E`, `--env-file=`: Sets the environment variables from file to be used during the task execution. Default is env.yml`
 - `--dry`: Enables dry-run mode, which prints out the commands to be executed without actually executing them.
 - `-v`, `--verbose`: Enables verbose mode, providing more detailed output and error messages during the task execution.
 - `--dbg`: Enables debug mode, providing even more detailed output and error messages during the task execution as well as diagnostic messages.
@@ -517,6 +518,24 @@ commands:
       echo "File name is $FILE_NAME"
   - name: third command
     copy: {src: $FILE_NAME, dest: /tmp/file2}
+```
+
+### Setting environment variables
+
+Environment variables can be set with `--env` / `-e` cli option. For example: `-e VAR1:VALUE1 -e VAR2:VALUE2`. Environment variables can also be set in the environment file (default `env.yml` can be changed with `--env-file` / `-E` cli flag). For example:
+```yaml
+env:  
+  VAR1: VALUE1
+  VAR2: VALUE2
+```
+Environment variable can be used in the playbook file with the expected syntax: `$VAR_NAME` or `${VAR_NAME}`. For example:
+
+```yaml
+commands:
+  - name: some command
+    script: echo $VAR1
+  - name: another command
+    copy: {"src": "testdata/*.csv", "dst": "$VAR2"}
 ```
 
 ## Targets

--- a/README.md
+++ b/README.md
@@ -538,6 +538,8 @@ commands:
     copy: {"src": "testdata/*.csv", "dst": "$VAR2"}
 ```
 
+In case of a conflict between environment variables set in the environment file and the cli, the cli variables will take precedence.
+
 ## Targets
 
 Targets are used to define the remote hosts to execute the tasks on. Targets can be defined in the playbook file or passed as a command-line argument. The following target types are supported:

--- a/pkg/secrets/memory_test.go
+++ b/pkg/secrets/memory_test.go
@@ -19,4 +19,25 @@ func TestMemoryProvider_Get(t *testing.T) {
 		_, err := m.Get("sec3")
 		assert.Error(t, err)
 	})
+
+	t.Run("get empty secret", func(t *testing.T) {
+		m := NewMemoryProvider(map[string]string{"sec1": ""})
+		val, err := m.Get("sec1")
+		assert.NoError(t, err)
+		assert.Equal(t, val, "")
+	})
+
+	t.Run("get secret with spaces", func(t *testing.T) {
+		m := NewMemoryProvider(map[string]string{"sec1": "  val1  "})
+		val, err := m.Get("sec1")
+		assert.NoError(t, err)
+		assert.Equal(t, val, "  val1  ")
+	})
+
+	t.Run("get secret with special characters", func(t *testing.T) {
+		m := NewMemoryProvider(map[string]string{"sec1": "val1!@#$%^&*()_+-={}|[]\\:\";'<>?,./"})
+		val, err := m.Get("sec1")
+		assert.NoError(t, err)
+		assert.Equal(t, val, "val1!@#$%^&*()_+-={}|[]\\:\";'<>?,./")
+	})
 }


### PR DESCRIPTION
relatated to https://github.com/umputun/spot/discussions/126

This PR adds basic support for env file in yaml format. The default is `env.yaml` but can be changed in the command line. In case this file is missing, it won't fail and will continue as usual, so the change is back-compatible.

example of env.yml:

```yml
vars:
  var1: val1
  var2: val2
```
