### PR TITLE
safer script processing 

### DIFF
--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -41,6 +41,20 @@ echo 'Goodbye, World!'`,
 			},
 		},
 		{
+			name: "multiline command without environment variables",
+			cmd: &Cmd{
+				Script: `echo 'Hello, World!'
+echo 'Goodbye, World!'`,
+			},
+			expectedScript: "",
+			expectedContents: []string{
+				"#!/bin/sh",
+				"set -e",
+				"echo 'Hello, World!'",
+				"echo 'Goodbye, World!'",
+			},
+		},
+		{
 			name: "multiline command with exports",
 			cmd: &Cmd{
 				Script: `echo 'Hello, World!'
@@ -74,6 +88,52 @@ export FOO='bar'`,
 			expectedScript: "",
 			expectedContents: []string{
 				"#!/bin/sh",
+				"set -e",
+				"echo 'Hello, World!'",
+				"export",
+				"echo 'Goodbye, World!'",
+				"export BAR",
+				"export FOO='bar'",
+				"echo setvar FOO=${FOO}",
+			},
+		},
+		{
+			name: "multiline command with shebang on non-first line",
+			cmd: &Cmd{
+				Script: `echo 'Hello, World!'
+#!/bin/bash
+export
+echo 'Goodbye, World!'
+export BAR
+export FOO='bar'`,
+			},
+			expectedScript: "",
+			expectedContents: []string{
+				"#!/bin/sh",
+				"set -e",
+				"echo 'Hello, World!'",
+				"#!/bin/bash",
+				"export",
+				"echo 'Goodbye, World!'",
+				"export BAR",
+				"export FOO='bar'",
+				"echo setvar FOO=${FOO}",
+			},
+		},
+		{
+			name: "multiline command with shebang on second line, but after initial empty line",
+			cmd: &Cmd{
+				Script: `
+#!/bin/bash
+echo 'Hello, World!'
+export
+echo 'Goodbye, World!'
+export BAR
+export FOO='bar'`,
+			},
+			expectedScript: "",
+			expectedContents: []string{
+				"#!/bin/bash",
 				"set -e",
 				"echo 'Hello, World!'",
 				"export",


### PR DESCRIPTION
This small PR addresses https://github.com/umputun/spot/issues/144#issuecomment-1653476516

1. Processes shebang on the first line only
2. Strips leading empty string that can be added due to some yaml formats
3. Simplify shebang detection, as it has to be on the first line