### PR TITLE
add support for on_exit deferring it for all the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,27 @@ example installing curl package if not installed already:
     cond: "! command -v curl"
 ```
 
+### Deferred actions (`on_exit`)
+
+Each command may have `on_exit` parameter defined. It allows executing a command on the remote host after the task with all commands is completed. The command is called regardless of the task's exit code.
+
+This is useful in several scenarios:
+
+- a temporary script copied to the remote host and executed and should be removed after execution with `on_exit: "rm -fv /tmp/script.sh"`
+- a service should be restarted after the new version is deployed with `on_exit: "systemctl restart myservice"`
+
+
+```yaml
+  - name: "copy script"
+    copy: {src: "testdata/script.sh", "dst": "/tmp/script.sh", "chmod+x": true}
+    on_exit: "rm -fv /tmp/script.sh" # register deferred action to remove script.sh after execution
+  - name: "run script"
+    script: "/tmp/script.sh"
+```
+
+In the example above, the `script.sh` is copied to the remote host, executed, and removed after completion of the task.
+
+
 ### Script Execution
 
 Spot allows executing scripts on remote hosts, or locally if `options.local` is set to true. Scripts can be executed in two different ways, depending on whether they are single-line or multi-line scripts.

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -30,6 +30,7 @@ type Cmd struct {
 	Options     CmdOptions        `yaml:"options" toml:"options,omitempty"`
 	Condition   string            `yaml:"cond" toml:"cond,omitempty"`
 	Register    []string          `yaml:"register" toml:"register"` // register variables from command
+	OnExit      string            `yaml:"on_exit" toml:"on_exit"`   // script to run on exit
 
 	Secrets  map[string]string `yaml:"-" toml:"-"` // loaded secrets, filled by playbook
 	SSHShell string            `yaml:"-" toml:"-"` // shell to use for ssh commands, filled by playbook

--- a/pkg/runner/commands.go
+++ b/pkg/runner/commands.go
@@ -29,12 +29,14 @@ type execCmd struct {
 	exec     executor.Interface
 	verbose  bool
 	sshShell string
+	onExit   string
 }
 
 type execCmdResp struct {
 	details string
 	verbose string
 	vars    map[string]string
+	onExit  execCmd
 }
 
 type execCmdErr struct {

--- a/pkg/runner/testdata/conf.yml
+++ b/pkg/runner/testdata/conf.yml
@@ -165,3 +165,34 @@ tasks:
           echo good command 2
       - name: good command
         script: echo good command 3
+
+  - name: with_onexit
+    commands:
+      - name: some command
+        script: |
+          echo good command 1
+          echo "file content" > /tmp/file.txt
+          echo good command 2
+        on_exit: |
+          echo "on exit called. task: ${SPOT_TASK}, host: ${SPOT_REMOTE_HOST}, error: ${SPOT_ERROR}"
+          cat /tmp/file.txt
+      - name: "print file info"
+        script: ls -la /tmp/file.txt
+
+  - name: with_onexit_failed
+    commands:
+      - name: some command
+        script: |
+          echo good command 1
+          ls /no-such-dir
+        on_exit: |
+          echo "on exit called on failed. task: ${SPOT_TASK}, host: ${SPOT_REMOTE_HOST}, error: ${SPOT_ERROR}"
+
+  - name: with_onexit_copy
+    commands:
+      - name: some command
+        copy: {"src": "testdata/conf.yml", "dst": "/tmp/conf-blah.yml", "mkdir": true, "force": true}
+        on_exit: |
+          echo "on exit called for copy. task: ${SPOT_TASK}, host: ${SPOT_REMOTE_HOST}, error: ${SPOT_ERROR}"
+          rm -fv /tmp/conf-blah.yml
+

--- a/schemas/playbook.json
+++ b/schemas/playbook.json
@@ -216,6 +216,9 @@
         "name": {
           "type": "string"
         },
+        "on_exit": {
+          "type": "string"
+        },
         "options": {
           "type": "object",
           "additionalProperties": false,
@@ -279,6 +282,10 @@
               "default": false
             },
             "recur": {
+              "type": "boolean",
+              "default": false
+            },
+            "chmod+x": {
               "type": "boolean",
               "default": false
             },


### PR DESCRIPTION
The goal is to add a per-task `on_exit` command that will be invoked on the task's completion on each server. The goal is to allow all kinds of cleanup actions, service restarts, and so on to be in a more logical place.

Currently, it is possible to add some cleanup commands, but for larger tasks, it is hard to follow, and having it right in the command should make it easier. 

For example:

```yaml
task:
  - name: "copy script"
    copy: {src: "testdata/script.sh", "dst": "/tmp/script.sh", "chmod+x": true}
    on_exit: "rm -fv /tmp/script.sh" # register deferred action to remove script.sh after execution

  - name: "run script"
    script: "/tmp/script.sh"
```

Here, we "register" the removal of `/tmp/script.sh`. This is somewhat similar to Go's deffer running the command on function completion, but in the case of Spot, it runs on task completion instead and on each remote server.