### PR TITLE
Local shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Spot supports the following command-line options:
 user: umputun                       # default ssh user. Can be overridden by -u flag or by inventory or host definition
 ssh_key: keys/id_rsa                # ssh key
 ssh_shell: /bin/bash                # shell to use for remote ssh execution, default is /bin/sh
+local_shell: /bin/bash              # shell to use for local execution, default is os shell
 inventory: /etc/spot/inventory.yml  # default inventory file. Can be overridden by --inventory flag
 
 # list of targets, i.e. hosts, inventory files or inventory URLs
@@ -239,6 +240,7 @@ In some cases, the rich syntax of the full playbook is not needed and can feel o
 user: umputun                       # default ssh user. Can be overridden by -u flag or by inventory or host definition
 ssh_key: keys/id_rsa                # ssh key
 ssh_shell: /bin/bash                # shell to use for remote ssh execution, default is /bin/sh
+local_shell: /bin/bash              # shell to use for local execution, default is os shell
 inventory: /etc/spot/inventory.yml  # default inventory file. Can be overridden by --inventory flag
 
 targets: ["devbox1", "devbox2", "h1.example.com:2222", "h2.example.com"] # list of host names from inventory and direct host ips

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -759,4 +760,26 @@ func TestHasShebang(t *testing.T) {
 			require.Equal(t, tc.exp, cmd.hasShebang(tc.inp))
 		})
 	}
+}
+
+func TestCmd_shell(t *testing.T) {
+	t.Run("shell is not set", func(t *testing.T) {
+		c := Cmd{}
+		assert.Equal(t, "/bin/sh", c.shell())
+	})
+
+	t.Run("shell is set", func(t *testing.T) {
+		c := Cmd{SSHShell: "/bin/bash"}
+		assert.Equal(t, "/bin/bash", c.shell())
+	})
+
+	t.Run("shell is not set, local", func(t *testing.T) {
+		c := Cmd{Options: CmdOptions{Local: true}}
+		assert.Equal(t, os.Getenv("SHELL"), c.shell())
+	})
+
+	t.Run("shell is set, local", func(t *testing.T) {
+		c := Cmd{LocalShell: "/bin/bash", Options: CmdOptions{Local: true}}
+		assert.Equal(t, "/bin/bash", c.shell())
+	})
 }

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -775,7 +775,11 @@ func TestCmd_shell(t *testing.T) {
 
 	t.Run("shell is not set, local", func(t *testing.T) {
 		c := Cmd{Options: CmdOptions{Local: true}}
-		assert.Equal(t, os.Getenv("SHELL"), c.shell())
+		exp := "/bin/sh"
+		if os.Getenv("SHELL") != "" {
+			exp = os.Getenv("SHELL")
+		}
+		assert.Equal(t, exp, c.shell())
 	})
 
 	t.Run("shell is set, local", func(t *testing.T) {

--- a/pkg/config/playbook_test.go
+++ b/pkg/config/playbook_test.go
@@ -23,6 +23,7 @@ func TestPlaybook_New(t *testing.T) {
 		assert.Equal(t, 1, len(c.Tasks), "single task")
 		assert.Equal(t, "umputun", c.User, "user")
 		assert.Equal(t, "/bin/sh", c.Tasks[0].Commands[0].SSHShell, "ssh shell")
+		assert.Equal(t, os.Getenv("SHELL"), c.Tasks[0].Commands[0].LocalShell, "local shell")
 
 		tsk := c.Tasks[0]
 		assert.Equal(t, 5, len(tsk.Commands), "5 commands")
@@ -197,19 +198,20 @@ func TestPlaybook_New(t *testing.T) {
 		t.Logf("%+v", c)
 		assert.Equal(t, 1, len(c.Tasks), "single task")
 		assert.Equal(t, "umputun", c.User, "user")
-		assert.Equal(t, "/bin/bash", c.Tasks[0].Commands[0].SSHShell, "ssh shell")
+		assert.Equal(t, "/bin/bash", c.Tasks[0].Commands[0].SSHShell, "remote ssh shell")
+		assert.Equal(t, "/bin/xxx", c.Tasks[0].Commands[0].LocalShell, "local local shell")
 
 		tsk := c.Tasks[0]
 		assert.Equal(t, 5, len(tsk.Commands), "5 commands")
 		assert.Equal(t, "deploy-remark42", tsk.Name, "task name")
 	})
-	t.Run("playbook with custom ssh shell override", func(t *testing.T) {
+	t.Run("playbook with custom shell overrides", func(t *testing.T) {
 		c, err := New("testdata/with-ssh-shell.yml", &Overrides{SSHShell: "/bin/zsh"}, nil)
 		require.NoError(t, err)
 		t.Logf("%+v", c)
 		assert.Equal(t, 1, len(c.Tasks), "single task")
 		assert.Equal(t, "umputun", c.User, "user")
-		assert.Equal(t, "/bin/zsh", c.Tasks[0].Commands[0].SSHShell, "ssh shell")
+		assert.Equal(t, "/bin/zsh", c.Tasks[0].Commands[0].SSHShell, "remote ssh shell")
 
 		tsk := c.Tasks[0]
 		assert.Equal(t, 5, len(tsk.Commands), "5 commands")

--- a/pkg/config/playbook_test.go
+++ b/pkg/config/playbook_test.go
@@ -23,7 +23,11 @@ func TestPlaybook_New(t *testing.T) {
 		assert.Equal(t, 1, len(c.Tasks), "single task")
 		assert.Equal(t, "umputun", c.User, "user")
 		assert.Equal(t, "/bin/sh", c.Tasks[0].Commands[0].SSHShell, "ssh shell")
-		assert.Equal(t, os.Getenv("SHELL"), c.Tasks[0].Commands[0].LocalShell, "local shell")
+		expShell := os.Getenv("SHELL")
+		if expShell == "" {
+			expShell = "/bin/sh"
+		}
+		assert.Equal(t, expShell, c.Tasks[0].Commands[0].LocalShell, "local shell")
 
 		tsk := c.Tasks[0]
 		assert.Equal(t, 5, len(tsk.Commands), "5 commands")

--- a/pkg/config/testdata/with-ssh-shell.yml
+++ b/pkg/config/testdata/with-ssh-shell.yml
@@ -1,5 +1,6 @@
 user: umputun
 ssh_shell: /bin/bash
+local_shell: /bin/xxx
 
 targets:
     remark42:


### PR DESCRIPTION
This PR adds a new top-level field to playbooks (both full and simplified versions), allowing to set the local shell (i.e. `local_shell=/bin/bash`)

This is because there are unpredictable and unexpected results if we run some scripts with local mode on a different host. For example, this simple script works fine with `#/bin/sh` but doesn't work correctly with `#/bin/zsh`

```
  - name: "make images"
    script: |
     IMAGES="website email-sender private-share"
      mkdir -p /tmp/web-images
      for image in ${IMAGES}; do
        echo "process image: ${image}"
        docker pull  example.com/miscs/${image}:latest
        docker save "example.com/miscs/${image}" -o "/tmp/web-images/${image}.tar"
      done
    options: {local: true}
```

The change is back compatible, i.e., if `local_shell` is not set, it will follow the old logic (`os.Getenv("SHELL")` with failback to `/bin/sh`)
