### PR TITLE
Do not select the default key with --ssh=agent

### DIFF
--- a/cmd/secrets/main_test.go
+++ b/cmd/secrets/main_test.go
@@ -184,7 +184,7 @@ func TestMainFunc(t *testing.T) {
 
 			// Replace the exit function with a custom one
 			exited := false
-			exitFunc = func(code int) {
+			exitFunc = func(int) {
 				exited = true
 			}
 

--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -315,7 +315,7 @@ func makePlaybook(opts options, inventory string) (*config.PlayBook, error) {
 }
 
 func makeRunner(opts options, pbook *config.PlayBook) (*runner.Process, error) {
-	sshKey, err := sshKey(opts.SSHKey, pbook)
+	sshKey, err := sshKey(opts.SSHAgent, opts.SSHKey, pbook)
 	if err != nil {
 		return nil, fmt.Errorf("can't get ssh key: %w", err)
 	}
@@ -381,7 +381,7 @@ func targetsForTask(targets []string, taskName string, pbook runner.Playbook) []
 }
 
 // get ssh key from cli or playbook. if no key is provided, use default ~/.ssh/id_rsa
-func sshKey(sshKey string, pbook *config.PlayBook) (key string, err error) {
+func sshKey(sshAgent bool, sshKey string, pbook *config.PlayBook) (key string, err error) {
 	if sshKey == "" && (pbook == nil || pbook.SSHKey != "") { // no key provided in cli
 		sshKey = pbook.SSHKey // use playbook's ssh_key
 	}
@@ -394,7 +394,9 @@ func sshKey(sshKey string, pbook *config.PlayBook) (key string, err error) {
 		if err != nil {
 			return "", fmt.Errorf("can't get current user: %w", err)
 		}
-		sshKey = filepath.Join(u.HomeDir, ".ssh", "id_rsa")
+		if !sshAgent {
+			sshKey = filepath.Join(u.HomeDir, ".ssh", "id_rsa")
+		}
 	}
 
 	log.Printf("[INFO] ssh key: %s", sshKey)

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -421,6 +421,21 @@ func Test_sshUserAndKey(t *testing.T) {
 			expectedKey:  filepath.Join(osUser.HomeDir, ".ssh", "id_rsa"),
 		},
 		{
+			name: "SSHAgent set no key in playbook and command line",
+			opts: options{
+				TaskNames: []string{"test_task"},
+				SSHUser:   "cmd_user",
+				SSHAgent:  true,
+			},
+			conf: config.PlayBook{
+				Tasks: []config.Task{
+					{Name: "test_task"},
+				},
+			},
+			expectedUser: "cmd_user",
+			expectedKey:  "",
+		},
+		{
 			name: "tilde expansion in key path",
 			opts: options{
 				TaskNames: []string{"test_task"},

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -26,7 +26,7 @@ func Test_main(t *testing.T) {
 	hostAndPort, teardown := startTestContainer(t)
 	defer teardown()
 
-	t.Run("with system shell set", func(t *testing.T) {
+	t.Run("with system shell set", func(*testing.T) {
 		args := []string{"simplotask", "--dbg", "--playbook=testdata/conf-local.yml", "--user=test",
 			"--key=testdata/test_ssh_key", "--target=" + hostAndPort}
 		os.Args = args

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -441,7 +441,7 @@ func Test_sshUserAndKey(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			key, err := sshKey(tc.opts.SSHKey, &tc.conf)
+			key, err := sshKey(tc.opts.SSHAgent, tc.opts.SSHKey, &tc.conf)
 			require.NoError(t, err, "sshKey should not return an error")
 			assert.Equal(t, tc.expectedKey, key, "key should match expected key")
 			sshUser, err := sshUser(tc.opts.SSHUser, &tc.conf)

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -231,7 +231,7 @@ func (l *Local) syncSrcToDst(ctx context.Context, src, dst string, excl []string
 func (l *Local) removeExtraDstFiles(ctx context.Context, src, dst string) error {
 	var pathsToDelete []string
 
-	err := filepath.Walk(dst, func(dstPath string, info os.FileInfo, err error) error {
+	err := filepath.Walk(dst, func(dstPath string, _ os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -949,7 +949,7 @@ func Test_shouldRunCmd(t *testing.T) {
 
 func TestGen(t *testing.T) {
 	mockPbook := &mocks.PlaybookMock{
-		TargetHostsFunc: func(name string) ([]config.Destination, error) {
+		TargetHostsFunc: func(string) ([]config.Destination, error) {
 			return []config.Destination{
 				{Name: "test1", Host: "host1", Port: 8080, User: "user1", Tags: []string{"tag1", "tag2"}},
 				{Name: "test2", Host: "host2", Port: 8081, User: "user2", Tags: []string{"tag3", "tag4"}},

--- a/pkg/secrets/aws_test.go
+++ b/pkg/secrets/aws_test.go
@@ -17,7 +17,7 @@ func TestAWSSecretsProvider_Get(t *testing.T) {
 	require.NoError(t, err, "failed to create AWSSecretsProvider")
 
 	sm := &mocks.SectretsManagerClient{
-		GetSecretValueFunc: func(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+		GetSecretValueFunc: func(_ context.Context, params *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
 			if *params.SecretId == "key1" {
 				res := "test-secret"
 				return &secretsmanager.GetSecretValueOutput{SecretString: &res}, nil


### PR DESCRIPTION
should address #170 

If no ssh key is specified and the `--ssh-agent` option is specified, do not select the default key