### PR TITLE
Secret masking improvements 

### DIFF
--- a/cmd/spot/testdata/conf.yml
+++ b/cmd/spot/testdata/conf.yml
@@ -8,6 +8,7 @@ targets:
 tasks:
 
   - name: task1
+    options: {secrets: ["sec1"]}
     commands:
       - name: wait
         script: sleep 1s
@@ -31,7 +32,7 @@ tasks:
           echo all good, 123
           echo secrets: $sec1 $sec2
           echo secrets md5: `echo -n "$sec1 $sec2" | md5sum`
-        options: {secrets: ["sec1", "sec2"]}
+        options: {secrets: ["sec2"]}
 
       - name: delete things
         delete: {"path": "/tmp/things", "recur": true}

--- a/pkg/executor/logger.go
+++ b/pkg/executor/logger.go
@@ -71,7 +71,9 @@ func (s *colorizedWriter) WithWriter(wr io.Writer) LogWriter {
 
 // Printf writes the given text to io.Writer with the colorized hostAddr prefix.
 func (s *colorizedWriter) Printf(format string, v ...any) {
-	fmt.Fprintf(s, format, v...)
+	msg := fmt.Sprintf(format, v...)
+	msg = maskSecrets(msg, s.secrets)
+	_, _ = fmt.Fprint(s, msg)
 }
 
 // Write writes the given byte slice to stdout with the colorized hostAddr prefix for each line.


### PR DESCRIPTION
Enforce masking of secrets in internal logger.  Also enforce masking  in colorized log if `Printf` used.

This PR implements the masking of secrets in logger output and revises how debugging is set up, with a focus on logs involving secrets. The secrets are made available only after the playbook is loaded, and they're now passed as parameters to setupLog function. Relevant tests were updated and an additional test case for Printf function with secrets was added.

see #181 