### PR TITLE
add option to enable agent forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Spot supports the following command-line options:
 - `-c`, `--concurrent=`: Sets the number of concurrent hosts to execute tasks. Defaults to `1`, which means hosts will be handled  sequentially.
 - `--timeout`: Sets the SSH timeout. Defaults to `30s`. User can also set the environment variable `$SPOT_TIMEOUT` to define the SSH timeout.
 - `--ssh-agent`: Enables using the SSH agent for authentication. Defaults to `false`. Users can also set the environment variable `SPOT_SSH_AGENT` to define the value.
+- `--forward-ssh-agent`: Enables forwarding of connections from an authentication agent. Defaults to `false`. Users can also set the environment variable `SPOT_FORWARD_SSH_AGENT` to define the value.
 - `--shell` - shell for remote ssh execution, default is `/bin/sh`. Users can also set the environment variable `SPOT_SHELL` to define the value.  
 - `-i`, `--inventory=`: Specifies the inventory file or URL to use for the task execution. Overrides the inventory file defined in the
   playbook file. Users can also set the environment variable `$SPOT_INVENTORY` to define the default inventory file path or url.

--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -31,13 +31,14 @@ type options struct {
 		AdHocCmd string `positional-arg-name:"command" description:"run ad-hoc command on target hosts"`
 	} `positional-args:"yes" positional-optional:"yes"`
 
-	PlaybookFile string        `short:"p" long:"playbook" env:"SPOT_PLAYBOOK" description:"playbook file" default:"spot.yml"`
-	TaskNames    []string      `short:"n" long:"task" description:"task name"`
-	Targets      []string      `short:"t" long:"target" description:"target name" default:"default"`
-	Concurrent   int           `short:"c" long:"concurrent" description:"concurrent tasks" default:"1"`
-	SSHTimeout   time.Duration `long:"timeout" env:"SPOT_TIMEOUT" description:"ssh timeout" default:"30s"`
-	SSHAgent     bool          `long:"ssh-agent" env:"SPOT_SSH_AGENT" description:"use ssh-agent"`
-	SSHShell     string        `long:"shell" env:"SPOT_SHELL" description:"shell to use for ssh" default:"/bin/sh"`
+	PlaybookFile    string        `short:"p" long:"playbook" env:"SPOT_PLAYBOOK" description:"playbook file" default:"spot.yml"`
+	TaskNames       []string      `short:"n" long:"task" description:"task name"`
+	Targets         []string      `short:"t" long:"target" description:"target name" default:"default"`
+	Concurrent      int           `short:"c" long:"concurrent" description:"concurrent tasks" default:"1"`
+	SSHTimeout      time.Duration `long:"timeout" env:"SPOT_TIMEOUT" description:"ssh timeout" default:"30s"`
+	SSHAgent        bool          `long:"ssh-agent" env:"SPOT_SSH_AGENT" description:"use ssh-agent"`
+	ForwardSSHAgent bool          `long:"forward-ssh-agent" env:"SPOT_FORWARD_SSH_AGENT" description:"use forward-ssh-agent"`
+	SSHShell        string        `long:"shell" env:"SPOT_SHELL" description:"shell to use for ssh" default:"/bin/sh"`
 
 	// overrides
 	Inventory string            `short:"i" long:"inventory" description:"inventory file or url [$SPOT_INVENTORY]"`
@@ -327,6 +328,10 @@ func makeRunner(opts options, pbook *config.PlayBook) (*runner.Process, error) {
 	}
 	if opts.SSHAgent {
 		connector = connector.WithAgent()
+	}
+
+	if opts.ForwardSSHAgent {
+		connector = connector.WithAgentForwarding()
 	}
 
 	r := runner.Process{

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -473,7 +473,7 @@ func Test_sshAgentForwarding(t *testing.T) {
 		Dbg:             true,
 	}
 
-	cmd := fmt.Sprintf("ssh-add -l | awk \"{ print \\$2 }\" > f1; echo \"%s\" > f2; diff f1 f2",
+	cmd := fmt.Sprintf("ssh-add -l | awk \"{ print \\$2 }\" > f1; echo %q > f2; diff f1 f2",
 		getKeyFingerprint(t, "testdata/test_ssh_key"))
 
 	opts.PositionalArgs.AdHocCmd = cmd

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -134,6 +134,7 @@ Spot supports the following command-line options:
 - `-c`, `--concurrent=`: Sets the number of concurrent hosts to execute tasks. Defaults to `1`, which means hosts will be handled  sequentially.
 - `--timeout`: Sets the SSH timeout. Defaults to `30s`. User can also set the environment variable `$SPOT_TIMEOUT` to define the SSH timeout.
 - `--ssh-agent`: Enables using the SSH agent for authentication. Defaults to `false`. Users can also set the environment variable `SPOT_SSH_AGENT` to define the value.
+- `--forward-ssh-agent`: Enables forwarding of connections from an authentication agent. Defaults to `false`. Users can also set the environment variable `SPOT_FORWARD_SSH_AGENT` to define the value.
 - `--shell` - shell for remote ssh execution, default is `/bin/sh`. Users can also set the environment variable `SPOT_SHELL` to define the value.  
 - `-i`, `--inventory=`: Specifies the inventory file or URL to use for the task execution. Overrides the inventory file defined in the
   playbook file. Users can also set the environment variable `$SPOT_INVENTORY` to define the default inventory file path or url.


### PR DESCRIPTION
This pull request introduces the forward-ssh-agent option, allowing users to leverage SSH agent forwarding when executing commands on remote hosts. This facilitates secure authentication by forwarding connections from a local authentication agent, such as ssh-agent, to the remote host. It’s particularly useful in environments where direct SSH access needs to be secured and simplified without exposing private key material.

If it isn't needed or doesn't fit the project's direction, feel free to decline this PR.