### PR TITLE
Allow registered vars to be populated across tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,27 @@ commands:
     copy: {src: $FILE_NAME, dest: /tmp/file2}
 ```
 
+Another unique feature of the registered variables is that they can be used not only in the subsequent commands for the current task but also in the subsequent tasks. This allows users to pass variables between tasks. In other words, the registered variables are populated to the environment of all the tasks in the playbook, automatically.
+
+example:
+
+```yaml
+tasks:
+  - name: set_register_var
+    commands:
+      - name: some command
+        script: |
+          echo good command 1
+          len=$(echo "file content" | wc -c)
+        register: [len]
+
+  - name: use_register_var
+    commands:
+      - name: some command
+        script: |
+          echo "len: $len"
+```
+
 ### Setting environment variables
 
 Environment variables can be set with `--env` / `-e` cli option. For example: `-e VAR1:VALUE1 -e VAR2:VALUE2`. Environment variables can also be set in the environment file (default `env.yml` can be changed with `--env-file` / `-E` cli flag). For example:

--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -368,7 +368,8 @@ func runTaskForTarget(ctx context.Context, r *runner.Process, taskName, targetNa
 	}
 	log.Printf("[INFO] completed: hosts:%d, commands:%d in %v\n",
 		res.Hosts, res.Commands, time.Since(st).Truncate(100*time.Millisecond))
-	r.Playbook.UpdateTasksTargets(res.Vars) // for dynamic targets
+	r.Playbook.UpdateTasksTargets(res.Vars)         // for dynamic targets
+	r.Playbook.UpdateRegisteredVars(res.Registered) // for registered vars, cross-task
 	return nil
 }
 

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -147,6 +147,30 @@ func Test_runCompleted(t *testing.T) {
 		})
 		t.Log("out\n", logOut)
 	})
+
+	t.Run("run with registered variables", func(t *testing.T) {
+		opts := options{
+			SSHUser:      "test",
+			SSHKey:       "testdata/test_ssh_key",
+			PlaybookFile: "testdata/conf.yml",
+			TaskNames:    []string{"set_register_var", "use_register_var"},
+			Targets:      []string{hostAndPort},
+			SecretsProvider: SecretsProvider{
+				Provider: "spot",
+				Conn:     "testdata/test-secrets.db",
+				Key:      "1234567890",
+			},
+			Dbg:     true,
+			Verbose: []bool{true},
+		}
+		logOut := captureStdout(t, func() {
+			err := run(opts)
+			require.NoError(t, err)
+		})
+		t.Log("out\n", logOut)
+		assert.Contains(t, logOut, " > setvar len=13")
+		assert.Contains(t, logOut, " > len: 13")
+	})
 }
 
 func Test_runCompletedSimplePlaybook(t *testing.T) {

--- a/cmd/spot/testdata/conf.yml
+++ b/cmd/spot/testdata/conf.yml
@@ -70,3 +70,17 @@ tasks:
         script: echo good command 1
       - name: wait
         wait: {cmd: "echo wait done", timeout: 5s, interval: 1s}
+
+  - name: set_register_var
+    commands:
+      - name: some command
+        script: |
+          echo good command 1
+          len=$(echo "file content" | wc -c)
+        register: [len]
+
+  - name: use_register_var
+    commands:
+      - name: some command
+        script: |
+          echo "len: $len"

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-pkgz/stringutils"
 	"gopkg.in/yaml.v3"
 )
 
@@ -212,15 +213,21 @@ func (cmd *Cmd) scriptFile(inp string, register []string) (r io.Reader) {
 	}
 
 	// each exported variable is printed as a setvar command to be captured by the caller
+	exported := []string{} // collect all exported variables to avoid duplicates in setvar output
 	if len(exports) > 0 {
 		for _, v := range exports {
 			buf.WriteString(fmt.Sprintf("echo setvar %s=${%s}\n", v, v))
+			exported = append(exported, v)
 		}
 	}
 
 	// each register variable is printed as a setvar command to be captured by the caller
 	if len(register) > 0 {
 		for _, v := range register {
+			if stringutils.Contains(v, exported) {
+				// if already exported, we don't need to print it again
+				continue
+			}
 			buf.WriteString(fmt.Sprintf("echo setvar %s=${%s}\n", v, v))
 		}
 	}

--- a/pkg/config/playbook.go
+++ b/pkg/config/playbook.go
@@ -437,6 +437,30 @@ func (p *PlayBook) UpdateTasksTargets(vars map[string]string) {
 	}
 }
 
+// UpdateRegisteredVars takes the list of registered vars from the caller handling task execution
+// and updates the environment variables of all commands in the playbook with the values from the list.
+func (p *PlayBook) UpdateRegisteredVars(vars map[string]string) {
+	if len(vars) == 0 {
+		return
+	}
+	log.Printf("[DEBUG] update registered vars %+v", vars)
+	for k, v := range vars {
+		for _, tsk := range p.Tasks {
+			for i, c := range tsk.Commands {
+				env := c.Environment
+				if env == nil {
+					env = make(map[string]string)
+				}
+				if _, ok := env[k]; ok { // don't allow override already set vars. TODO: not sure if this is correct
+					continue
+				}
+				env[k] = v
+				tsk.Commands[i].Environment = env
+			}
+		}
+	}
+}
+
 // loadInventory loads the inventory data from the specified location (file or URL) and returns it as an InventoryData struct.
 // The inventory data is parsed as either YAML or TOML, depending on the file extension.
 // The method also performs some additional processing on the inventory data:

--- a/pkg/runner/mocks/playbook.go
+++ b/pkg/runner/mocks/playbook.go
@@ -27,6 +27,9 @@ import (
 //			TaskFunc: func(name string) (*config.Task, error) {
 //				panic("mock out the Task method")
 //			},
+//			UpdateRegisteredVarsFunc: func(vars map[string]string)  {
+//				panic("mock out the UpdateRegisteredVars method")
+//			},
 //			UpdateTasksTargetsFunc: func(vars map[string]string)  {
 //				panic("mock out the UpdateTasksTargets method")
 //			},
@@ -49,6 +52,9 @@ type PlaybookMock struct {
 	// TaskFunc mocks the Task method.
 	TaskFunc func(name string) (*config.Task, error)
 
+	// UpdateRegisteredVarsFunc mocks the UpdateRegisteredVars method.
+	UpdateRegisteredVarsFunc func(vars map[string]string)
+
 	// UpdateTasksTargetsFunc mocks the UpdateTasksTargets method.
 	UpdateTasksTargetsFunc func(vars map[string]string)
 
@@ -70,17 +76,23 @@ type PlaybookMock struct {
 			// Name is the name argument value.
 			Name string
 		}
+		// UpdateRegisteredVars holds details about calls to the UpdateRegisteredVars method.
+		UpdateRegisteredVars []struct {
+			// Vars is the vars argument value.
+			Vars map[string]string
+		}
 		// UpdateTasksTargets holds details about calls to the UpdateTasksTargets method.
 		UpdateTasksTargets []struct {
 			// Vars is the vars argument value.
 			Vars map[string]string
 		}
 	}
-	lockAllSecretValues    sync.RWMutex
-	lockAllTasks           sync.RWMutex
-	lockTargetHosts        sync.RWMutex
-	lockTask               sync.RWMutex
-	lockUpdateTasksTargets sync.RWMutex
+	lockAllSecretValues      sync.RWMutex
+	lockAllTasks             sync.RWMutex
+	lockTargetHosts          sync.RWMutex
+	lockTask                 sync.RWMutex
+	lockUpdateRegisteredVars sync.RWMutex
+	lockUpdateTasksTargets   sync.RWMutex
 }
 
 // AllSecretValues calls AllSecretValuesFunc.
@@ -198,6 +210,38 @@ func (mock *PlaybookMock) TaskCalls() []struct {
 	mock.lockTask.RLock()
 	calls = mock.calls.Task
 	mock.lockTask.RUnlock()
+	return calls
+}
+
+// UpdateRegisteredVars calls UpdateRegisteredVarsFunc.
+func (mock *PlaybookMock) UpdateRegisteredVars(vars map[string]string) {
+	if mock.UpdateRegisteredVarsFunc == nil {
+		panic("PlaybookMock.UpdateRegisteredVarsFunc: method is nil but Playbook.UpdateRegisteredVars was just called")
+	}
+	callInfo := struct {
+		Vars map[string]string
+	}{
+		Vars: vars,
+	}
+	mock.lockUpdateRegisteredVars.Lock()
+	mock.calls.UpdateRegisteredVars = append(mock.calls.UpdateRegisteredVars, callInfo)
+	mock.lockUpdateRegisteredVars.Unlock()
+	mock.UpdateRegisteredVarsFunc(vars)
+}
+
+// UpdateRegisteredVarsCalls gets all the calls that were made to UpdateRegisteredVars.
+// Check the length with:
+//
+//	len(mockedPlaybook.UpdateRegisteredVarsCalls())
+func (mock *PlaybookMock) UpdateRegisteredVarsCalls() []struct {
+	Vars map[string]string
+} {
+	var calls []struct {
+		Vars map[string]string
+	}
+	mock.lockUpdateRegisteredVars.RLock()
+	calls = mock.calls.UpdateRegisteredVars
+	mock.lockUpdateRegisteredVars.RUnlock()
 	return calls
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -53,6 +53,7 @@ type Playbook interface {
 	TargetHosts(name string) ([]config.Destination, error)
 	AllSecretValues() []string
 	UpdateTasksTargets(vars map[string]string)
+	UpdateRegisteredVars(vars map[string]string)
 }
 
 // ProcResp holds the information about processed commands and hosts.

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -171,6 +171,7 @@ func TestProcess_Run(t *testing.T) {
 		assert.Contains(t, outWriter.String(), `> var bar: 9`)
 		assert.Contains(t, outWriter.String(), `> var baz: qux`, "was not overwritten")
 		assert.EqualValues(t, map[string]string{"bar": "9", "bar2": "10", "baz": "zzzzz", "foo": "6", "foo2": "7"}, res.Vars)
+		assert.EqualValues(t, map[string]string{"bar2": "10", "foo2": "7"}, res.Registered)
 	})
 
 	t.Run("with secrets", func(t *testing.T) {


### PR DESCRIPTION
see #196

This PR changes the scope of registered variables, making them available to all subsequent tasks. The only thing I still doubt is whether those vars should overwrite locally set variables (set by command) and act as immutable (can be set once). For now, I made them immutable, but may reconsider it if needed.

cc: @koolay

