### PR TITLE
don't set default override for ssh shell #212

### DIFF
--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -39,7 +39,7 @@ type options struct {
 	SSHTimeout      time.Duration `long:"timeout" env:"SPOT_TIMEOUT" description:"ssh timeout" default:"30s"`
 	SSHAgent        bool          `long:"ssh-agent" env:"SPOT_SSH_AGENT" description:"use ssh-agent"`
 	ForwardSSHAgent bool          `long:"forward-ssh-agent" env:"SPOT_FORWARD_SSH_AGENT" description:"use forward-ssh-agent"`
-	SSHShell        string        `long:"shell" env:"SPOT_SHELL" description:"shell to use for ssh" default:"/bin/sh"`
+	SSHShell        string        `long:"shell" env:"SPOT_SHELL" description:"enforce non-default shell to use for ssh" default:""`
 
 	// overrides
 	Inventory string            `short:"i" long:"inventory" description:"inventory file or url [$SPOT_INVENTORY]"`

--- a/pkg/config/playbook_test.go
+++ b/pkg/config/playbook_test.go
@@ -255,9 +255,10 @@ func TestPlaybook_New(t *testing.T) {
 		assert.Equal(t, "/bin/xxx", c.Tasks[0].Commands[0].LocalShell, "local local shell")
 
 		tsk := c.Tasks[0]
-		assert.Equal(t, 5, len(tsk.Commands), "5 commands")
+		assert.Equal(t, 6, len(tsk.Commands), "5 commands")
 		assert.Equal(t, "deploy-remark42", tsk.Name, "task name")
 	})
+
 	t.Run("playbook with custom shell overrides", func(t *testing.T) {
 		c, err := New("testdata/with-ssh-shell.yml", &Overrides{SSHShell: "/bin/zsh"}, nil)
 		require.NoError(t, err)
@@ -267,7 +268,7 @@ func TestPlaybook_New(t *testing.T) {
 		assert.Equal(t, "/bin/zsh", c.Tasks[0].Commands[0].SSHShell, "remote ssh shell")
 
 		tsk := c.Tasks[0]
-		assert.Equal(t, 5, len(tsk.Commands), "5 commands")
+		assert.Equal(t, 6, len(tsk.Commands), "5 commands")
 		assert.Equal(t, "deploy-remark42", tsk.Name, "task name")
 	})
 }

--- a/pkg/config/testdata/with-ssh-shell.yml
+++ b/pkg/config/testdata/with-ssh-shell.yml
@@ -22,6 +22,10 @@ tasks:
           ls -la /srv
           du -hcs /srv
 
+      - name: some single-line command
+        script: |
+          ls -la /srv
+
       - name: git
         before: "echo before git"
         after: "echo after git"


### PR DESCRIPTION
This regression was introduced some time ago and sets the default SSH shell to `/bin/sh`. This setting is considered the highest priority in CLI overrides, and consequently, it is enforced even if a custom SSH shell is set in the playbook.

fixes #212 
