### PR TITLE
Exclude goreleaser from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "goreleaser/goreleaser-action"
     groups:
       "GitHub Actions updates":
         patterns:


### PR DESCRIPTION
Goreleaser is known to break backwards compatibility in minor versions and shouldn't be updated automatically.