### PR TITLE
add missing cleanup for local temp script file

### DIFF
--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -285,7 +285,7 @@ func (ex *Remote) Delete(ctx context.Context, remoteFile string, opts *DeleteOpt
 			}
 		}
 
-		log.Printf("[INFO] deleted recursively %s", remoteFile)
+		log.Printf("[INFO] deleted recursively %s from %s", remoteFile, ex.hostName)
 	}
 
 	if fileInfo.IsDir() && !recursive {

--- a/pkg/runner/commands.go
+++ b/pkg/runner/commands.go
@@ -455,6 +455,8 @@ func (ec *execCmd) prepScript(ctx context.Context, s string, r io.Reader) (cmd, 
 		// remove local copy of the script after upload or in case of error
 		if err := os.Remove(tmp.Name()); err != nil {
 			log.Printf("[WARN] can't remove local temp script %s: %v", tmp.Name(), err)
+		} else {
+			log.Printf("[DEBUG] removed local temp script %s", tmp.Name())
 		}
 	}()
 	// make the script executable locally, upload preserves the permissions


### PR DESCRIPTION
this file is uploaded to remote temp and removed properly as a part of returned teardown(). However the local file created first and the removal was missing. 

This PR adds the removal right after the upload done. It also adds a test for the cleanup

see #242 