### PR TITLE
Add custom SSH temp directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Spot supports the following command-line options:
 - `--ssh-agent`: Enables using the SSH agent for authentication. Defaults to `false`. Users can also set the environment variable `SPOT_SSH_AGENT` to define the value.
 - `--forward-ssh-agent`: Enables forwarding of connections from an authentication agent. Defaults to `false`. Users can also set the environment variable `SPOT_FORWARD_SSH_AGENT` to define the value.
 - `--shell` - shell for remote ssh execution, default is `/bin/sh`. Users can also set the environment variable `SPOT_SHELL` to define the value.  
+- `--local-shell` - shell for local execution, default is os shell. Users can also set the environment variable `SPOT_LOCAL_SHELL` to define the value.
+- `--temp` - temporary directory for remote execution, default is `/tmp`. Users can also set the environment variable `SPOT_TEMP_DIR` to define the value.
 - `-i`, `--inventory=`: Specifies the inventory file or URL to use for the task execution. Overrides the inventory file defined in the
   playbook file. Users can also set the environment variable `$SPOT_INVENTORY` to define the default inventory file path or url.
 - `-u`, `--user=`: Specifies the SSH user to use when connecting to remote hosts. Overrides the user defined in the playbook file .
@@ -170,6 +172,7 @@ Spot supports the following command-line options:
 user: umputun                       # default ssh user. Can be overridden by -u flag or by inventory or host definition
 ssh_key: keys/id_rsa                # ssh key
 ssh_shell: /bin/bash                # shell to use for remote ssh execution, default is /bin/sh
+ssh_temp_dir: /tmp                  # temporary directory for remote execution, default is /tmp
 local_shell: /bin/bash              # shell to use for local execution, default is os shell
 inventory: /etc/spot/inventory.yml  # default inventory file. Can be overridden by --inventory flag
 
@@ -241,6 +244,7 @@ In some cases, the rich syntax of the full playbook is not needed and can feel o
 user: umputun                       # default ssh user. Can be overridden by -u flag or by inventory or host definition
 ssh_key: keys/id_rsa                # ssh key
 ssh_shell: /bin/bash                # shell to use for remote ssh execution, default is /bin/sh
+ssh_temp_dir: /tmp                  # temporary directory for remote execution, default is /tmp
 local_shell: /bin/bash              # shell to use for local execution, default is os shell
 inventory: /etc/spot/inventory.yml  # default inventory file. Can be overridden by --inventory flag
 

--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -40,6 +40,7 @@ type options struct {
 	SSHAgent        bool          `long:"ssh-agent" env:"SPOT_SSH_AGENT" description:"use ssh-agent"`
 	ForwardSSHAgent bool          `long:"forward-ssh-agent" env:"SPOT_FORWARD_SSH_AGENT" description:"use forward-ssh-agent"`
 	SSHShell        string        `long:"shell" env:"SPOT_SHELL" description:"enforce non-default shell to use for ssh" default:""`
+	SSHTempDir      string        `long:"temp" env:"SPOT_TEMP" description:"temporary directory for ssh" default:""`
 
 	// overrides
 	Inventory string            `short:"i" long:"inventory" description:"inventory file or url [$SPOT_INVENTORY]"`
@@ -353,6 +354,7 @@ func makeRunner(opts options, pbook *config.PlayBook) (*runner.Process, error) {
 		Verbose2:    len(opts.Verbose) > 1,
 		Dry:         opts.Dry,
 		SSHShell:    opts.SSHShell,
+		SSHTempDir:  opts.SSHTempDir,
 	}
 	log.Printf("[DEBUG] runner created: concurrency:%d, connector: %s, ssh_shell:%q, verbose:%v, dry:%v, only:%v, skip:%v",
 		r.Concurrency, r.Connector, r.SSHShell, r.Verbose, r.Dry, r.Only, r.Skip)

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -398,49 +398,53 @@ func Test_runGen_goTmplFile(t *testing.T) {
 
 func TestMakeRunnerTempDir(t *testing.T) {
 	tests := []struct {
-		name           string
-		opts           options
-		playbook       *config.PlayBook
-		wantTmpDir     string
-		wantLogMessage string
+		name       string
+		opts       options
+		playbook   *config.PlayBook
+		wantTmpDir string
 	}{
 		{
 			name: "command line temp dir",
 			opts: options{
-				SSHTempDir: "/tmp/cmd",
+				SSHTempDir: "/tmp/custom/cmd",
+				SSHKey:     "testdata/test_ssh_key", // Add test SSH key
 			},
 			playbook:   &config.PlayBook{},
-			wantTmpDir: "/tmp/cmd",
+			wantTmpDir: "/tmp/custom/cmd",
 		},
 		{
 			name: "playbook temp dir",
-			opts: options{},
-			playbook: &config.PlayBook{
-				SSHTempDir: "/tmp/playbook",
+			opts: options{
+				SSHKey: "testdata/test_ssh_key", // Add test SSH key
 			},
-			wantTmpDir: "/tmp/playbook",
+			playbook: &config.PlayBook{
+				SSHTempDir: "/tmp/custom/playbook",
+			},
+			wantTmpDir: "/tmp/custom/playbook",
 		},
 		{
-			name:       "no temp dir",
-			opts:       options{},
+			name: "no temp dir",
+			opts: options{
+				SSHKey: "testdata/test_ssh_key", // Add test SSH key
+			},
 			playbook:   &config.PlayBook{},
 			wantTmpDir: "",
 		},
 		{
 			name: "command line overrides playbook",
 			opts: options{
-				SSHTempDir: "/tmp/cmd",
+				SSHTempDir: "/tmp/custom/cmd",
+				SSHKey:     "testdata/test_ssh_key", // Add test SSH key
 			},
 			playbook: &config.PlayBook{
-				SSHTempDir: "/tmp/playbook",
+				SSHTempDir: "/tmp/custom/playbook",
 			},
-			wantTmpDir: "/tmp/cmd",
+			wantTmpDir: "/tmp/custom/cmd",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// if command line temp dir is empty, use playbook's temp dir
 			if tt.opts.SSHTempDir == "" && tt.playbook.SSHTempDir != "" {
 				tt.opts.SSHTempDir = tt.playbook.SSHTempDir
 			}
@@ -458,7 +462,7 @@ func TestRunWithCustomTempDir(t *testing.T) {
 	opts := options{
 		SSHUser:      "test",
 		SSHKey:       "testdata/test_ssh_key",
-		SSHTempDir:   "/tmp/custom-spot",
+		SSHTempDir:   "/tmp/custom/spot", // Updated path
 		PlaybookFile: "testdata/conf2.yml",
 		TaskNames:    []string{"task1"},
 		Targets:      []string{hostAndPort},
@@ -472,10 +476,8 @@ func TestRunWithCustomTempDir(t *testing.T) {
 	})
 	t.Log("out\n", logOut)
 
-	// verify the temp dir was used in the commands
-	assert.Contains(t, logOut, "/tmp/custom-spot/.spot-")
-	// verify temp dir was properly cleaned up
-	assert.Contains(t, logOut, "deleted recursively /tmp/custom-spot/.spot-")
+	assert.Contains(t, logOut, "/tmp/custom/spot/.spot-")
+	assert.Contains(t, logOut, "deleted recursively /tmp/custom/spot/.spot-")
 }
 
 func Test_connectFailed(t *testing.T) {

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -35,6 +35,7 @@ type Cmd struct {
 
 	Secrets    map[string]string `yaml:"-" toml:"-"` // loaded secrets, filled by playbook
 	SSHShell   string            `yaml:"-" toml:"-"` // shell to use for ssh commands, filled by playbook
+	SSHTempDir string            `yaml:"-" toml:"-"` // temporary directory for ssh commands, filled by playbook
 	LocalShell string            `yaml:"-" toml:"-"` // shell to use for local commands, filled by playbooks
 }
 

--- a/pkg/config/testdata/with-ssh-config.yml
+++ b/pkg/config/testdata/with-ssh-config.yml
@@ -1,0 +1,14 @@
+user: umputun
+ssh_shell: /bin/bash
+ssh_temp_dir: /tmp/spot
+local_shell: /bin/fish
+
+targets:
+  remark42:
+    hosts: [{name: "h1", host: "h1.example.com"}, {host: "h2.example.com"}]
+
+tasks:
+  - name: test-task
+    commands:
+      - name: test
+        script: echo "test"

--- a/pkg/runner/commands_test.go
+++ b/pkg/runner/commands_test.go
@@ -806,3 +806,24 @@ func Test_execCmd_prepScript(t *testing.T) {
 		assert.Contains(t, buf.String(), "[DEBUG] removed local temp script")
 	})
 }
+
+func Test_execCmd_uniqueTmp(t *testing.T) {
+	t.Run("default tmp location", func(t *testing.T) {
+		ec := &execCmd{}
+		tmp1 := ec.uniqueTmp("/tmp/.spot-")
+		tmp2 := ec.uniqueTmp("/tmp/.spot-")
+		t.Logf("tmp1: %s, tmp2: %s", tmp1, tmp2)
+
+		require.NotEqual(t, tmp1, tmp2, "uniqueTmp should generate unique temporary directory names")
+		require.True(t, strings.HasPrefix(tmp1, "/tmp/.spot-"), "uniqueTmp should use the provided prefix")
+		require.True(t, strings.HasPrefix(tmp2, "/tmp/.spot-"), "uniqueTmp should use the provided prefix")
+	})
+
+	t.Run("custom tmp location", func(t *testing.T) {
+		ec := &execCmd{sshTmpDir: "/custom/tmp"}
+		tmp := ec.uniqueTmp("/tmp/.spot-")
+		t.Logf("tmp: %s", tmp)
+
+		require.True(t, strings.HasPrefix(tmp, "/custom/tmp/.spot-"), "uniqueTmp should use the custom temporary directory")
+	})
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -36,6 +36,7 @@ type Process struct {
 	Verbose2    bool
 	Dry         bool
 	SSHShell    string
+	SSHTempDir  string
 
 	Skip []string
 	Only []string
@@ -227,7 +228,7 @@ func (p *Process) runTaskOnHost(ctx context.Context, tsk *config.Task, hostAddr,
 		stCmd := time.Now()
 
 		ec := execCmd{cmd: cmd, hostAddr: hostAddr, hostName: hostName, tsk: &activeTask, exec: remote,
-			verbose: p.Verbose, verbose2: p.Verbose2, sshShell: p.SSHShell, onExit: cmd.OnExit}
+			verbose: p.Verbose, verbose2: p.Verbose2, sshShell: p.SSHShell, sshTmpDir: p.SSHTempDir, onExit: cmd.OnExit}
 		ec = p.pickCmdExecutor(cmd, ec, hostAddr, hostName) // pick executor on dry run or local command
 
 		repHostAddr, repHostName := ec.hostAddr, ec.hostName


### PR DESCRIPTION
This commit adds support for specifying a custom SSH temporary directory. It includes:

- New `SSHTempDir` field in PlayBook and Target structs
- Command line flag and environment variable for setting temp dir
- Logic to use custom temp dir in command execution
- Tests for new functionality
- Update documentation and examples