### PR TITLE
Support dynamic register variable names with templating #261

### DIFF
--- a/cmd/secrets/main_test.go
+++ b/cmd/secrets/main_test.go
@@ -135,7 +135,7 @@ func TestSpotSecrets_ListWithAndWithoutPrefix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			os.Args = append([]string{"spot"}, tc.args...)
 
-			// Capture the standard output
+			// capture the standard output
 			oldStdout := os.Stdout
 			r, w, _ := os.Pipe()
 			os.Stdout = w
@@ -143,7 +143,7 @@ func TestSpotSecrets_ListWithAndWithoutPrefix(t *testing.T) {
 			err = runCommand()
 			require.NoError(t, err)
 
-			// Restore the original standard output
+			// restore the original standard output
 			_ = w.Close()
 			os.Stdout = oldStdout
 
@@ -174,15 +174,15 @@ func TestMainFunc(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Set the command-line arguments
+			// set the command-line arguments
 			os.Args = append([]string{"spot"}, tc.args...)
 
-			// Capture the standard output
+			// capture the standard output
 			oldStdout := os.Stdout
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 
-			// Replace the exit function with a custom one
+			// replace the exit function with a custom one
 			exited := false
 			exitFunc = func(int) {
 				exited = true
@@ -190,15 +190,15 @@ func TestMainFunc(t *testing.T) {
 
 			main()
 
-			// Restore the original exit function and standard output
+			// restore the original exit function and standard output
 			exitFunc = os.Exit
 			_ = w.Close()
 			os.Stdout = oldStdout
 
-			// Check if the custom exit function was called
+			// check if the custom exit function was called
 			assert.True(t, exited)
 
-			// Check the captured standard output
+			// check the captured standard output
 			var buf bytes.Buffer
 			_, _ = io.Copy(&buf, r)
 			output := buf.String()

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -407,7 +407,7 @@ func TestMakeRunnerTempDir(t *testing.T) {
 			name: "command line temp dir",
 			opts: options{
 				SSHTempDir: "/tmp/custom/cmd",
-				SSHKey:     "testdata/test_ssh_key", // Add test SSH key
+				SSHKey:     "testdata/test_ssh_key", // add test SSH key
 			},
 			playbook:   &config.PlayBook{},
 			wantTmpDir: "/tmp/custom/cmd",
@@ -415,7 +415,7 @@ func TestMakeRunnerTempDir(t *testing.T) {
 		{
 			name: "playbook temp dir",
 			opts: options{
-				SSHKey: "testdata/test_ssh_key", // Add test SSH key
+				SSHKey: "testdata/test_ssh_key", // add test SSH key
 			},
 			playbook: &config.PlayBook{
 				SSHTempDir: "/tmp/custom/playbook",
@@ -425,7 +425,7 @@ func TestMakeRunnerTempDir(t *testing.T) {
 		{
 			name: "no temp dir",
 			opts: options{
-				SSHKey: "testdata/test_ssh_key", // Add test SSH key
+				SSHKey: "testdata/test_ssh_key", // add test SSH key
 			},
 			playbook:   &config.PlayBook{},
 			wantTmpDir: "",
@@ -434,7 +434,7 @@ func TestMakeRunnerTempDir(t *testing.T) {
 			name: "command line overrides playbook",
 			opts: options{
 				SSHTempDir: "/tmp/custom/cmd",
-				SSHKey:     "testdata/test_ssh_key", // Add test SSH key
+				SSHKey:     "testdata/test_ssh_key", // add test SSH key
 			},
 			playbook: &config.PlayBook{
 				SSHTempDir: "/tmp/custom/playbook",
@@ -462,7 +462,7 @@ func TestRunWithCustomTempDir(t *testing.T) {
 	opts := options{
 		SSHUser:      "test",
 		SSHKey:       "testdata/test_ssh_key",
-		SSHTempDir:   "/tmp/custom/spot", // Updated path
+		SSHTempDir:   "/tmp/custom/spot", // updated path
 		PlaybookFile: "testdata/conf2.yml",
 		TaskNames:    []string{"task1"},
 		Targets:      []string{hostAndPort},
@@ -1008,7 +1008,7 @@ func TestEnvVars(t *testing.T) {
 				if err != nil {
 					t.Fatalf("could not create temp file: %v", err)
 				}
-				defer os.Remove(file.Name()) // Clean up
+				defer os.Remove(file.Name()) // clean up
 
 				if _, err = file.WriteString(tt.envFileData); err != nil {
 					t.Fatalf("could not write to temp file: %v", err)
@@ -1070,7 +1070,7 @@ func startTestContainer(t *testing.T) (hostAndPort string, teardown func()) {
 
 // captureStdout captures everything written to stdout within the function fn
 func captureStdout(t *testing.T, fn func()) string {
-	// Keep backup of the real stdout
+	// keep backup of the real stdout
 	old := os.Stdout
 	defer func() { os.Stdout = old }()
 

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -89,8 +89,8 @@ func (cmd *Cmd) GetScript() (command string, rdr io.Reader) {
 	}
 
 	elems := strings.Split(cmd.Script, "\n")
-	// If there are multiple lines, we need to use a script file.
-	// Export presence should be treated as multiline for env vars to be set. The same thing for register variables.
+	// if there are multiple lines, we need to use a script file.
+	// export presence should be treated as multiline for env vars to be set. The same thing for register variables.
 	if len(elems) > 1 || strings.Contains(cmd.Script, "export") || len(cmd.Register) > 0 {
 		log.Printf("[DEBUG] command %q is multiline, using script file", cmd.Name)
 		return "", cmd.scriptFile(cmd.Script, cmd.Register)

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -756,7 +756,7 @@ func TestHasShebang(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := &Cmd{} // Assuming Cmd is your type with hasShebang method
+			cmd := &Cmd{} // assuming Cmd is your type with hasShebang method
 			require.Equal(t, tc.exp, cmd.hasShebang(tc.inp))
 		})
 	}

--- a/pkg/config/deepcopy/deepcopy.go
+++ b/pkg/config/deepcopy/deepcopy.go
@@ -29,16 +29,16 @@ func Copy(src interface{}) interface{} {
 		return nil
 	}
 
-	// Make the interface a reflect.Value
+	// make the interface a reflect.Value
 	original := reflect.ValueOf(src)
 
-	// Make a copy of the same type as the original.
+	// make a copy of the same type as the original.
 	cpy := reflect.New(original.Type()).Elem()
 
-	// Recursively copy the original.
+	// recursively copy the original.
 	copyRecursive(original, cpy)
 
-	// Return the copy as an interface.
+	// return the copy as an interface.
 	return cpy.Interface()
 }
 
@@ -56,7 +56,7 @@ func copyRecursive(original, cpy reflect.Value) {
 	// handle according to original's Kind
 	switch original.Kind() {
 	case reflect.Ptr:
-		// Get the actual value being pointed to.
+		// get the actual value being pointed to.
 		originalValue := original.Elem()
 
 		// if  it isn't valid, return.
@@ -67,14 +67,14 @@ func copyRecursive(original, cpy reflect.Value) {
 		copyRecursive(originalValue, cpy.Elem())
 
 	case reflect.Interface:
-		// If this is a nil, don't do anything
+		// if this is a nil, don't do anything
 		if original.IsNil() {
 			return
 		}
-		// Get the value for the interface, not the pointer.
+		// get the value for the interface, not the pointer.
 		originalValue := original.Elem()
 
-		// Get the value by calling Elem().
+		// get the value by calling Elem().
 		copyValue := reflect.New(originalValue.Type()).Elem()
 		copyRecursive(originalValue, copyValue)
 		cpy.Set(copyValue)
@@ -85,9 +85,9 @@ func copyRecursive(original, cpy reflect.Value) {
 			cpy.Set(reflect.ValueOf(t))
 			return
 		}
-		// Go through each field of the struct and copy it.
+		// go through each field of the struct and copy it.
 		for i := 0; i < original.NumField(); i++ {
-			// The Type's StructField for a given field is checked to see if StructField.PkgPath
+			// the Type's StructField for a given field is checked to see if StructField.PkgPath
 			// is set to determine if the field is exported or not because CanSet() returns false
 			// for settable fields.  I'm not sure why.  -mohae
 			if original.Type().Field(i).PkgPath != "" {
@@ -100,7 +100,7 @@ func copyRecursive(original, cpy reflect.Value) {
 		if original.IsNil() {
 			return
 		}
-		// Make a new slice and copy each element.
+		// make a new slice and copy each element.
 		cpy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
 		for i := 0; i < original.Len(); i++ {
 			copyRecursive(original.Index(i), cpy.Index(i))

--- a/pkg/config/deepcopy/deepcopy_test.go
+++ b/pkg/config/deepcopy/deepcopy_test.go
@@ -221,7 +221,7 @@ func TestMostTypes(t *testing.T) {
 		return
 	}
 
-	// Go through each field and check to see it got copied properly
+	// go through each field and check to see it got copied properly
 	if cpy.String != test.String {
 		t.Errorf("String: got %v; want %v", cpy.String, test.String)
 	}
@@ -579,7 +579,7 @@ Interfaces:
 // not meant to be exhaustive
 // nolint
 func TestComplexSlices(t *testing.T) {
-	orig3Int := [][][]int{[][]int{[]int{1, 2, 3}, []int{11, 22, 33}}, [][]int{[]int{7, 8, 9}, []int{66, 77, 88, 99}}}
+	orig3Int := [][][]int{{{1, 2, 3}, {11, 22, 33}}, {{7, 8, 9}, {66, 77, 88, 99}}}
 	cpyI := Copy(orig3Int).([][][]int)
 	if (*reflect.SliceHeader)(unsafe.Pointer(&orig3Int)).Data == (*reflect.SliceHeader)(unsafe.Pointer(&cpyI)).Data {
 		t.Error("[][][]int: address of copy was the same as original; they should be different")
@@ -609,7 +609,7 @@ func TestComplexSlices(t *testing.T) {
 	}
 
 sliceMap:
-	slMap := []map[int]string{map[int]string{0: "a", 1: "b"}, map[int]string{10: "k", 11: "l", 12: "m"}}
+	slMap := []map[int]string{{0: "a", 1: "b"}, {10: "k", 11: "l", 12: "m"}}
 	cpyM := Copy(slMap).([]map[int]string)
 	if (*reflect.SliceHeader)(unsafe.Pointer(&slMap)).Data == (*reflect.SliceHeader)(unsafe.Pointer(&cpyM)).Data {
 		t.Error("[]map[int]string: address of copy was the same as original; they should be different")
@@ -659,11 +659,11 @@ var AStruct = A{
 	UintSl: []uint{0, 1, 2, 3},
 	Map:    map[string]int{"a": 1, "b": 2},
 	MapB: map[string]*B{
-		"hi":  &B{Vals: []string{"hello", "bonjour"}},
-		"bye": &B{Vals: []string{"good-bye", "au revoir"}},
+		"hi":  {Vals: []string{"hello", "bonjour"}},
+		"bye": {Vals: []string{"good-bye", "au revoir"}},
 	},
 	SliceB: []B{
-		B{Vals: []string{"Ciao", "Aloha"}},
+		{Vals: []string{"Ciao", "Aloha"}},
 	},
 	B: B{Vals: []string{"42"}},
 	T: time.Now(),
@@ -948,13 +948,13 @@ func TestIssue9(t *testing.T) {
 
 	testB := Biz{
 		Epsilon: map[int]*Bar{
-			0: &Bar{},
-			1: &Bar{
+			0: {},
+			1: {
 				Beta:  "don't panic",
 				Gamma: 42,
 				Delta: nil,
 			},
-			2: &Bar{
+			2: {
 				Beta:  "sudo make me a sandwich.",
 				Gamma: 11,
 				Delta: &Foo{
@@ -1010,10 +1010,10 @@ func TestIssue9(t *testing.T) {
 
 	// test that map keys are deep copied
 	testC := map[*Foo][]string{
-		&Foo{Alpha: "Henry Dorsett Case"}: []string{
+		{Alpha: "Henry Dorsett Case"}: {
 			"Cutter",
 		},
-		&Foo{Alpha: "Molly Millions"}: []string{
+		{Alpha: "Molly Millions"}: {
 			"Rose Kolodny",
 			"Cat Mother",
 			"Steppin' Razor",
@@ -1056,8 +1056,8 @@ func TestIssue9(t *testing.T) {
 	}
 
 	testD := map[Bizz]string{
-		Bizz{&Foo{"Neuromancer"}}: "Rio",
-		Bizz{&Foo{"Wintermute"}}:  "Berne",
+		{&Foo{"Neuromancer"}}: "Rio",
+		{&Foo{"Wintermute"}}:  "Berne",
 	}
 	copyD := Copy(testD).(map[Bizz]string)
 	if len(copyD) != len(testD) {

--- a/pkg/config/playbook_test.go
+++ b/pkg/config/playbook_test.go
@@ -751,7 +751,7 @@ func TestPlayBook_checkConfig(t *testing.T) {
 }
 
 func TestPlayBook_loadSecrets(t *testing.T) {
-	// Mock secret provider
+	// mock secret provider
 	secProvider := mocks.SecretProvider{
 		GetFunc: func(key string) (string, error) {
 			if key == "secret1" {

--- a/pkg/runner/testdata/register_templates.yml
+++ b/pkg/runner/testdata/register_templates.yml
@@ -1,0 +1,102 @@
+user: test
+
+targets:
+  localhost:
+    hosts: [{host: "localhost", name: "local"}]
+
+tasks:
+  - name: register_with_template_vars
+    commands:
+      - name: register with static name
+        script: |
+          export STATIC_VAR="static-test"
+          export DYNAMIC_VAR="mydynamic"
+          echo "Setting STATIC_VAR=$STATIC_VAR"
+        register: ["STATIC_VAR", "DYNAMIC_VAR"]
+
+      - name: register with env var
+        script: |
+          # Just directly register a variable with the expected name after template expansion
+          export DYNAMIC_mydynamic="dynamic-test-value"
+          # Echo the variable for registration
+          echo "setvar DYNAMIC_mydynamic=dynamic-test-value"
+        # This DYNAMIC_{DYNAMIC_VAR} will be expanded to DYNAMIC_mydynamic
+        register: ["DYNAMIC_{DYNAMIC_VAR}"]
+
+      - name: register with SPOT_REMOTE_ADDR
+        script: |
+          # This will create a variable with the host address in the name
+          export VAR_localhost="host-specific-value"
+          echo "Setting VAR_localhost=$VAR_localhost"
+        register: ["VAR_{SPOT_REMOTE_ADDR}"]
+      
+      - name: register with SPOT_REMOTE_NAME
+        script: |
+          # This will create a variable with the host name in the name
+          export HOST_localhost="hostname-specific-value"
+          echo "Setting HOST_localhost=$HOST_localhost"
+        register: ["HOST_{SPOT_REMOTE_NAME}"]
+        
+      - name: register with SPOT_REMOTE_USER
+        script: |
+          # This will create a variable with the command prefix
+          export CMD_test="command-template-value"
+          echo "Setting CMD_test=$CMD_test"
+        register: ["CMD_{SPOT_REMOTE_USER}"]
+
+      - name: check all registered variables
+        script: |
+          # Dump all env variables to see what's available
+          echo "=== Dumping all environment variables ==="
+          env
+          
+          echo "=== End of environment dump ==="
+          
+          echo "STATIC_VAR='${STATIC_VAR}'"
+          echo "DYNAMIC_VAR='${DYNAMIC_VAR}'"
+          echo "DYNAMIC_mydynamic='${DYNAMIC_mydynamic}'"
+          echo "VAR_localhost='${VAR_localhost}'"
+          echo "HOST_localhost='${HOST_localhost}'"
+          echo "CMD_test='${CMD_test}'"
+          
+          # Verify all variables are set correctly
+          [ "$STATIC_VAR" = "static-test" ] || { echo "ERROR: STATIC_VAR is wrong"; exit 1; }
+          [ "$DYNAMIC_mydynamic" = "dynamic-test-value" ] || { echo "ERROR: DYNAMIC_mydynamic is wrong"; exit 2; }
+          [ "$VAR_localhost" = "host-specific-value" ] || { echo "ERROR: VAR_localhost is wrong"; exit 3; }
+          [ "$HOST_localhost" = "hostname-specific-value" ] || { echo "ERROR: HOST_localhost is wrong"; exit 4; }
+          
+          echo "SUCCESS: All variables are correctly registered and accessible"
+
+  - name: verify_variable_propagation
+    commands:
+      - name: check propagated variables
+        script: |
+          # Dump all environment variables to see what's coming through
+          echo "=== SECOND TASK - Dumping all environment variables ==="
+          env | sort
+          echo "=== End of environment dump ==="
+          
+          # Display current variable values
+          echo "STATIC_VAR='${STATIC_VAR}'"
+          echo "DYNAMIC_VAR='${DYNAMIC_VAR}'"
+          echo "DYNAMIC_mydynamic='${DYNAMIC_mydynamic}'"
+          echo "VAR_localhost='${VAR_localhost}'"
+          echo "HOST_localhost='${HOST_localhost}'"
+          echo "CMD_test='${CMD_test}'"
+          
+          # Verify registered variables with simple checks
+          # Print actual vs expected values for debugging
+          echo "Expected STATIC_VAR='static-test', actual='${STATIC_VAR}'"
+          echo "Expected DYNAMIC_mydynamic='dynamic-test-value', actual='${DYNAMIC_mydynamic}'"
+          echo "Expected VAR_localhost='host-specific-value', actual='${VAR_localhost}'"
+          echo "Expected HOST_localhost='hostname-specific-value', actual='${HOST_localhost}'"
+          echo "Expected CMD_test='command-template-value', actual='${CMD_test}'"
+          
+          # Check that all variables are propagated correctly
+          [ "$STATIC_VAR" = "static-test" ] || { echo "ERROR: STATIC_VAR is wrong"; exit 1; }
+          [ "$DYNAMIC_mydynamic" = "dynamic-test-value" ] || { echo "ERROR: DYNAMIC_mydynamic is wrong"; exit 2; }
+          [ "$VAR_localhost" = "host-specific-value" ] || { echo "ERROR: VAR_localhost is wrong"; exit 3; }
+          [ "$HOST_localhost" = "hostname-specific-value" ] || { echo "ERROR: HOST_localhost is wrong"; exit 4; }
+          [ "$CMD_test" = "command-template-value" ] || { echo "ERROR: CMD_test is wrong"; exit 5; }
+          
+          echo "SUCCESS: All variables are correctly propagated between tasks"

--- a/pkg/secrets/ansible_vault.go
+++ b/pkg/secrets/ansible_vault.go
@@ -24,14 +24,14 @@ func NewAnsibleVaultProvider(vaultPath, secret string) (*AnsibleVaultProvider, e
 		return nil, fmt.Errorf("%s is not a regular file", vaultPath)
 	}
 
-	// Decrypt ansible-vault
+	// decrypt ansible-vault
 	decryptedVault, err := vault.DecryptFile(vaultPath, secret)
 	if err != nil {
 		return nil, fmt.Errorf("error decrypting file: %s", vaultPath)
 	}
 	log.Printf("[INFO] ansible vault file decrypted")
 
-	// Unmarshal decrypted data
+	// unmarshal decrypted data
 	m := make(map[string]interface{})
 	err = yaml.Unmarshal([]byte(decryptedVault), &m)
 	if err != nil {

--- a/pkg/secrets/spot_test.go
+++ b/pkg/secrets/spot_test.go
@@ -106,7 +106,7 @@ func TestInternalProvider(t *testing.T) {
 			_, err = provider.Get("test_key")
 			require.Error(t, err)
 
-			// Test List function
+			// test List function
 			keys, err := provider.List("")
 			require.NoError(t, err)
 			assert.Contains(t, keys, "test_key2")
@@ -149,7 +149,7 @@ func setupTestContainers(t *testing.T) (pc testcontainers.Container, ps string, 
 	require.NoError(t, err)
 	pgConnString := fmt.Sprintf("postgres://postgres:password@%s:%d/postgres?sslmode=disable", pgHost, pgPort.Int())
 
-	// MySQL container
+	// mySQL container
 	mysqlReq := testcontainers.ContainerRequest{
 		Image:        "mysql:8",
 		ExposedPorts: []string{"3306/tcp"},


### PR DESCRIPTION
## Summary
- Added ability to use template variables in register directives
- Fixed environment variable expansion in script preparation and register variable matching
- Implemented substitution for both predefined SPOT vars and environment variables
- Added test files to verify that expanded variable names match correctly

Fixes #261