### PR TITLE
Configure Dependabot to only provide security updates for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       "Go modules updates":
         dependency-type: "production"
+        applies-to: "security-updates"


### PR DESCRIPTION
This change modifies the Dependabot configuration to only provide security updates for Go packages, eliminating regular version updates that can be noisy.