### PR TITLE
Fix environment variable expansion issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,31 @@ echo "All done! $FOO $BAR"
 
 By using this approach, Spot enables users to write and execute more complex scripts, providing greater flexibility and power in managing remote hosts or local environments.
 
+**Environment Variable Escaping**
+
+Spot handles special characters in environment variable values to prevent unwanted shell expansion:
+
+- **Positional parameters** (`$0` through `$9`): Automatically protected from expansion using single quotes
+- **Escaped dollar** (`\$`): Treated as literal `$` (no expansion)
+- **Regular variables** (`$HOME`, `${USER}`, etc.): Allowed to expand normally
+
+Examples:
+
+```yaml
+commands:
+  - name: bcrypt password example
+    script: echo "Password hash: $BCRYPT_HASH"
+    env: 
+      # The $2 won't be expanded as a positional parameter
+      BCRYPT_HASH: "$2a$14$G.j2F3fm9wluTougUU52sOzePOvvpujjRrCoVp5qWVZ6qRJh58ISC"
+
+  - name: literal dollar example
+    script: echo "Literal: $LITERAL"
+    env:
+      # \$HOME will be treated as literal text "$HOME"
+      LITERAL: "\$HOME"
+```
+
 Users can also set any custom shebang for the script by adding `#!` at the beginning of the script. For example:
 
 ```yaml

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -233,6 +233,63 @@ echo 'Goodbye, World!'`,
 				"echo setvar foo=${foo}",
 			},
 		},
+		{
+			name: "environment variables with positional parameters",
+			cmd: &Cmd{
+				Script: "echo $BCRYPT",
+				Environment: map[string]string{
+					"BCRYPT": "$2a$14$G.j2F3fm9wluTougUU52sOzePOvvpujjRrCoVp5qWVZ6qRJh58ISC",
+					"MIXED":  "qwe$rty$123",
+					"NORMAL": "$HOME/path",
+				},
+			},
+			expectedScript:   `/bin/sh -c 'export BCRYPT='$2a$14$G.j2F3fm9wluTougUU52sOzePOvvpujjRrCoVp5qWVZ6qRJh58ISC'; export MIXED='qwe$rty$123'; export NORMAL="$HOME/path"; echo $BCRYPT'`,
+			expectedContents: nil,
+		},
+		{
+			name: "environment variables with escaped dollar",
+			cmd: &Cmd{
+				Script: "echo $VAR",
+				Environment: map[string]string{
+					"VAR": `\$HOME/\$USER`,
+				},
+			},
+			expectedScript:   `/bin/sh -c 'export VAR='$HOME/$USER'; echo $VAR'`,
+			expectedContents: nil,
+		},
+		{
+			name: "escaped dollar with positional parameter",
+			cmd: &Cmd{
+				Script: "echo $VAR",
+				Environment: map[string]string{
+					"VAR": `prefix\$2suffix`,
+				},
+			},
+			expectedScript:   `/bin/sh -c 'export VAR='prefix$2suffix'; echo $VAR'`,
+			expectedContents: nil,
+		},
+		{
+			name: "environment variable with single quotes",
+			cmd: &Cmd{
+				Script: "echo $VAR",
+				Environment: map[string]string{
+					"VAR": "foo'bar$1",
+				},
+			},
+			expectedScript:   `/bin/sh -c 'export VAR='foo'"'"'bar$1'; echo $VAR'`,
+			expectedContents: nil,
+		},
+		{
+			name: "mixed positional and normal variables",
+			cmd: &Cmd{
+				Script: "echo $VAR",
+				Environment: map[string]string{
+					"VAR": "$USER has $1 item",
+				},
+			},
+			expectedScript:   `/bin/sh -c 'export VAR='$USER has $1 item'; echo $VAR'`,
+			expectedContents: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/executor/logger.go
+++ b/pkg/executor/logger.go
@@ -168,8 +168,8 @@ func isAlphanumeric(s string) bool {
 		isUppercase := r >= 'A' && r <= 'Z'
 		isDigit := r >= '0' && r <= '9'
 		isUnderscore := r == '_'
-		
-		// If character is not alphanumeric or underscore, return false
+
+		// if character is not alphanumeric or underscore, return false
 		if !isLowercase && !isUppercase && !isDigit && !isUnderscore {
 			return false
 		}

--- a/pkg/executor/logger_test.go
+++ b/pkg/executor/logger_test.go
@@ -313,12 +313,12 @@ func TestMaskSecrets(t *testing.T) {
 		{"1234567890 xyz $%^&", []string{"1234567890"}, "**** xyz $%^&"},
 		{"secret@domain.com", []string{"secret@domain.com"}, "****"},
 		{"key=secret,val=secret", []string{"secret"}, "key=****,val=****"},
-		// New test cases for special characters and periods
+		// new test cases for special characters and periods
 		{"password123#", []string{"password123#"}, "****"},
 		{"password. with period", []string{"password."}, "**** with period"},
 		{"special!characters@in#password", []string{"special!characters@in#password"}, "****"},
 		{"token321.", []string{"token321."}, "****"},
-		// Test case from the issue where the script is shown with secrets
+		// test case from the issue where the script is shown with secrets
 		{"secret=\"token321.\"; secret_special=\"password123#\"; echo \"${secret} ${secret_special}\"",
 			[]string{"token321.", "password123#"}, "secret=\"****\"; secret_special=\"****\"; echo \"${secret} ${secret_special}\""},
 	}


### PR DESCRIPTION
## Summary
- Automatically protect positional parameters (`$0`-`$9`) from shell expansion
- Add support for escaped dollar (`\$`) to create literal dollar signs
- Preserve normal variable expansion for `$HOME`, `${USER}`, etc.

## Problem
As reported in #285, environment variables containing positional parameters (like bcrypt hashes with `$2a$14$...`) were being corrupted by shell expansion. Additionally, there was no way to create literal dollar signs in environment values.

## Solution
The fix detects positional parameters and escaped dollars, then uses single quotes to prevent expansion for those values while keeping double quotes for normal variables.

### Examples:
```yaml
env:
  # Bcrypt hash - $2 is preserved
  BCRYPT: "$2a$14$G.j2F3fm9wluTougUU52sOzePOvvpujjRrCoVp5qWVZ6qRJh58ISC"
  
  # Literal dollar - \$ becomes $
  LITERAL: "\$HOME"
  
  # Normal expansion still works
  HOME_DIR: "$HOME"
```

### Changes Made:
1. Modified `formatEnvVar()` in `pkg/config/command.go` to detect and handle special cases
2. Added comprehensive tests for all scenarios
3. Updated README.md with documentation and examples
4. Fixed comment casing issues found by unfuck-ai-comments

### Testing:
- All existing tests pass
- Added new tests for positional parameters, escaped dollars, and edge cases
- Manually verified with test playbooks

Fixes #285