### PR TITLE
Add short flag -s for --skip option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ gofmt -s -w $(find . -type f -name "*.go" -not -path "./vendor/*") && go generat
 - Never commit without running completion sequence
 - Run tests and linter after making significant changes to verify functionality
 - IMPORTANT: Never put into commit message any mention of Claude or Claude Code
-- Do not include "Test plan" sections in PR descriptions
+- IMPORTANT: Never include "Test plan" sections in PR descriptions
 - Do not add comments that describe changes, progress, or historical modifications
 - Comments should only describe the current state and purpose of the code, not its history or evolution
 - Use `go:generate` for generating mocks, never modify generated files manually
@@ -194,6 +194,7 @@ gofmt -s -w $(find . -type f -name "*.go" -not -path "./vendor/*") && go generat
   - If unable to fix an issue with the current approach, report the problem and ask for guidance
   - Focus on minimal changes to address the specific issue at hand
   - Preserve the existing patterns and conventions of the codebase
+- If README.md updated, doc site generation should be run with `make prep-site` command
 
 ## Spot-Specific Libraries
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ prep-site:
 	sed -i '' 's|^.*/workflows/ci.yml.*$$||' site/docs/index.md
 
 site:
-	@rm -f  site/public/*
+	@rm -rf  site/public/*
 	@docker rm -f spot-site
 	docker build -f Dockerfile.site --progress=plain -t spot.site .
 	docker run -d --name=spot-site spot.site

--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -50,7 +50,7 @@ type options struct {
 	EnvFile   string            `short:"E" long:"env-file" env:"SPOT_ENV_FILE" description:"environment variables from file" default:"env.yml"`
 
 	// commands filter
-	Skip []string `long:"skip" description:"skip commands"`
+	Skip []string `short:"s" long:"skip" description:"skip commands"`
 	Only []string `long:"only" description:"run only commands"`
 
 	// secrets


### PR DESCRIPTION
## Summary
- Added `-s` as a short flag for the `--skip` option to match user expectations and common CLI conventions
- Fixed Makefile `site` target to properly handle directory removal with `rm -rf`
- Updated documentation generation command in CLAUDE.md to use `make prep-site`
- Added rule to never include test plans in PR descriptions

Related #308