### PR TITLE
Issue 311 support task tagging

### DIFF
--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -42,6 +42,10 @@ type options struct {
 	SSHShell        string        `long:"shell" env:"SPOT_SHELL" description:"enforce non-default shell to use for ssh" default:""`
 	SSHTempDir      string        `long:"temp" env:"SPOT_TEMP" description:"temporary directory for ssh" default:""`
 
+	// tasks filter
+	Tags     []string `long:"tags" description:"only run tasks that match one or more of the specified tags"`
+	SkipTags []string `long:"skip-tags" description:"skip tasks that match one or more of the specified tags"`
+
 	// overrides
 	Inventory string            `short:"i" long:"inventory" description:"inventory file or url [$SPOT_INVENTORY]"`
 	SSHUser   string            `short:"u" long:"user" description:"ssh user"`
@@ -355,6 +359,8 @@ func makeRunner(opts options, pbook *config.PlayBook) (*runner.Process, error) {
 		Dry:         opts.Dry,
 		SSHShell:    opts.SSHShell,
 		SSHTempDir:  opts.SSHTempDir,
+		Tags:        opts.Tags,
+		SkipTags:    opts.SkipTags,
 	}
 	log.Printf("[DEBUG] runner created: concurrency:%d, connector: %s, ssh_shell:%q, verbose:%v, dry:%v, only:%v, skip:%v",
 		r.Concurrency, r.Connector, r.SSHShell, r.Verbose, r.Dry, r.Only, r.Skip)

--- a/pkg/config/playbook.go
+++ b/pkg/config/playbook.go
@@ -67,7 +67,7 @@ type Task struct {
 	OnError  string     `yaml:"on_error" toml:"on_error"`
 	Targets  []string   `yaml:"targets" toml:"targets"`           // optional list of targets to run task on, names or groups
 	Options  CmdOptions `yaml:"options" toml:"options,omitempty"` // options for all commands
-        Tags     []string    `yaml:"tags" toml:"tags"` // optional list of tags to add to tasks
+	Tags     []string   `yaml:"tags" toml:"tags"`                 // optional list of tags to add to tasks
 }
 
 // Target defines hosts to run commands on

--- a/pkg/config/playbook.go
+++ b/pkg/config/playbook.go
@@ -67,6 +67,7 @@ type Task struct {
 	OnError  string     `yaml:"on_error" toml:"on_error"`
 	Targets  []string   `yaml:"targets" toml:"targets"`           // optional list of targets to run task on, names or groups
 	Options  CmdOptions `yaml:"options" toml:"options,omitempty"` // options for all commands
+        Tags     []string    `yaml:"tags" toml:"tags"` // optional list of tags to add to tasks
 }
 
 // Target defines hosts to run commands on


### PR DESCRIPTION
This change adds ability to tag tasks. 

In the playbook, you can add `tags` to each task:

```
---
user: ubuntu
ssh_key: "<PATH_TO_SSH_KEY>"
ssh_shell: "/bin/bash"
local_shell: "/bin/bash"
inventory: "spot_inventory.yaml"

tasks:
- name: My tagged task
  tags: ['my-tag']
  commands:
    - name: Run the check and store result
      script: 'echo "hello moto"'
      options:
        sudo: true
        ignore_errors: true
  targets:
    - database_primary_node
```

To run tasks with matching tags: 

```
spot -p <PATH_TO_PLAYBOOK_YAML> --tags=my-tag 
```

To skip tasks with matching skip-tags:

```
spot -p <PATH_TO_PLAYBOOK_YAML> --skip-tags=my-test 
```
 