### PR TITLE
Fix multiline wait swallowing errors, wire delete exclude through

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,13 @@ Deletes a file or directory on the remote host(s), optionally can remove recursi
 
 Delete also supports a list format to remove multiple paths at once.
 
+Notes on `exclude`:
+- It requires `recur: true`, as it filters the contents of a directory tree.
+- It cannot be combined with the `sudo` option, as sudo deletion is performed with a plain shell command that cannot apply exclusion patterns.
+- Patterns are matched with forward slashes on all platforms; a backslash is treated as a path separator, so it cannot be used to escape glob metacharacters.
+- A pattern ending in `/*` (e.g. `logs/*` or `data*/*`) also protects the matching directory itself, keeping it and its contents.
+- If no pattern matches anything, the whole tree is removed (a mistyped pattern will not silently preserve files); a `[WARN]` is logged in that case.
+
 #### `wait`
 
 Waits for the specified command to finish on the remote host(s) with 0 error code. This command is useful when a user needs to wait for a service to start before executing the next command. Allows to specify the timeout as well as check interval.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -4,7 +4,7 @@ package executor
 
 import (
 	"context"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 )
@@ -47,35 +47,72 @@ type DeleteOpts struct {
 	Exclude   []string // exclude files matching the given patterns
 }
 
-func isExcluded(path string, excl []string) bool {
-	pathSegments := strings.Split(path, string(filepath.Separator))
+// normalizeSlashes converts windows separators to forward slashes,
+// exclude patterns and remote paths always use forward slashes.
+func normalizeSlashes(s string) string { return strings.ReplaceAll(s, `\`, "/") }
+
+// isExcluded reports whether fpath matches any of the exclude patterns. A pattern ending in "/*"
+// also matches the directory it names, so the whole subtree is protected, but this directory match
+// only applies when fpath is itself a directory. This prevents a pattern like "dir*/*" from
+// excluding a plain file such as "data.txt". Patterns and paths are compared with forward slashes.
+func isExcluded(fpath string, isDir bool, excl []string) bool {
+	pathSegments := strings.Split(normalizeSlashes(fpath), "/")
+
+	// normalize the patterns once, splitting off the optional "/*" directory suffix
+	type exPattern struct {
+		full, dir    string
+		isDirPattern bool
+	}
+	patterns := make([]exPattern, 0, len(excl))
+	for _, ex := range excl {
+		ex = normalizeSlashes(ex)
+		dir, isDirPattern := strings.CutSuffix(ex, "/*")
+		patterns = append(patterns, exPattern{full: ex, dir: dir, isDirPattern: isDirPattern})
+	}
+
 	for i := range pathSegments {
-		subpath := filepath.Join(pathSegments[:i+1]...)
-		for _, ex := range excl {
-			match, err := filepath.Match(ex, subpath)
-			if err != nil {
-				continue
-			}
-			if match {
+		subpath := strings.Join(pathSegments[:i+1], "/")
+		for _, p := range patterns {
+			if match, err := path.Match(p.full, subpath); err == nil && match {
 				return true
 			}
-			// treat directory in exclusion list as excluding all of its contents
-			if strings.TrimSuffix(ex, "/*") == subpath {
-				return true
+			// a "dir/*" pattern also protects the named directory itself, so the walker can skip
+			// it; restricted to directories so a file matching the glob prefix is not excluded
+			if isDir && p.isDirPattern {
+				if match, err := path.Match(p.dir, subpath); err == nil && match {
+					return true
+				}
 			}
 		}
 	}
 	return false
 }
 
-func isExcludedSubPath(path string, excl []string) bool {
-	subpath := filepath.Join(path, "*")
+// isExcludedSubPath checks if the path is a proper ancestor of any excluded path,
+// i.e. removing the path recursively would also remove an excluded entry.
+func isExcludedSubPath(fpath string, excl []string) bool {
+	var pathSegments []string
+	if fpath != "." {
+		pathSegments = strings.Split(normalizeSlashes(fpath), "/")
+	}
 	for _, ex := range excl {
-		match, err := filepath.Match(subpath, strings.TrimSuffix(ex, "/*"))
-		if err != nil {
+		exTrimmed := strings.TrimSuffix(normalizeSlashes(ex), "/*")
+		if exTrimmed == "" {
 			continue
 		}
-		if match {
+		exSegments := strings.Split(exTrimmed, "/")
+		if len(pathSegments) >= len(exSegments) {
+			continue // path is not a proper ancestor of the excluded path
+		}
+		matched := true
+		for i, seg := range pathSegments {
+			ok, err := path.Match(exSegments[i], seg)
+			if err != nil || !ok {
+				matched = false
+				break
+			}
+		}
+		if matched {
 			return true
 		}
 	}

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -15,29 +15,38 @@ func Test_isExcluded(t *testing.T) {
 	testCases := []struct {
 		name     string
 		path     string
+		isDir    bool
 		excl     []string
 		expected bool
 	}{
-		{"exact match", "test.txt", []string{"test.txt"}, true},
-		{"glob match", "test.txt", []string{"*.txt"}, true},
-		{"no match", "test.txt", []string{"*.jpg"}, false},
-		{"invalid pattern", "test.txt", []string{"["}, false},
-		{"empty exclusion list", "test.txt", []string{}, false},
-		{"empty path", "", []string{"*.txt"}, false},
-		{"directory exclusion", "folder/test.txt", []string{"folder/*"}, true},
-		{"directory exclusion without wildcard", "folder/test.txt", []string{"folder"}, true},
-		{"recursive exclusion", "folder/subfolder/test.txt", []string{"folder/*"}, true},
-		{"recursive exclusion without wildcard", "folder/subfolder/test.txt", []string{"folder"}, true},
-		{"partial match", "folder/test.txt", []string{"folder/*test.txt"}, true},
-		{"non-wildcard match", "folder/test.txt", []string{"folder/"}, false},
-		{"match with ? wildcard", "test.txt", []string{"t?st.txt"}, true},
-		{"match with multiple wildcards", "folder/subfolder/test.txt", []string{"folder/*/test.txt"}, true},
-		{"case sensitivity", "Test.txt", []string{"test.txt"}, false},
+		{"exact match", "test.txt", false, []string{"test.txt"}, true},
+		{"glob match", "test.txt", false, []string{"*.txt"}, true},
+		{"no match", "test.txt", false, []string{"*.jpg"}, false},
+		{"invalid pattern", "test.txt", false, []string{"["}, false},
+		{"empty exclusion list", "test.txt", false, []string{}, false},
+		{"empty path", "", false, []string{"*.txt"}, false},
+		{"directory exclusion", "folder/test.txt", false, []string{"folder/*"}, true},
+		{"directory exclusion without wildcard", "folder/test.txt", false, []string{"folder"}, true},
+		{"recursive exclusion", "folder/subfolder/test.txt", false, []string{"folder/*"}, true},
+		{"recursive exclusion without wildcard", "folder/subfolder/test.txt", false, []string{"folder"}, true},
+		{"partial match", "folder/test.txt", false, []string{"folder/*test.txt"}, true},
+		{"non-wildcard match", "folder/test.txt", false, []string{"folder/"}, false},
+		{"match with ? wildcard", "test.txt", false, []string{"t?st.txt"}, true},
+		{"match with multiple wildcards", "folder/subfolder/test.txt", false, []string{"folder/*/test.txt"}, true},
+		{"case sensitivity", "Test.txt", false, []string{"test.txt"}, false},
+		{"glob directory exclusion matches directory itself", "dir1", true, []string{"dir*/*"}, true},
+		{"glob directory exclusion matches nested file", "dir1/keep.txt", false, []string{"dir*/*"}, true},
+		{"glob directory exclusion no match", "other", false, []string{"dir*/*"}, false},
+		{"glob directory pattern does not exclude plain file", "data.txt", false, []string{"da*/*"}, false},
+		{"glob directory pattern does not match same-name file", "dir1", false, []string{"dir*/*"}, false},
+		{"plain directory pattern protects directory", "folder", true, []string{"folder/*"}, true},
+		{"windows path separators normalized", `folder\test.txt`, false, []string{"folder/*"}, true},
+		{"windows exclude pattern normalized", "folder/test.txt", false, []string{`folder\*`}, true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := isExcluded(tc.path, tc.excl)
+			actual := isExcluded(tc.path, tc.isDir, tc.excl)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
@@ -55,6 +64,13 @@ func Test_isExcludedSubPath(t *testing.T) {
 		{"sub-path with case sensitivity", "/user/docs", []string{"/user/Docs/123"}, false},
 		{"sub-path not excluded", "/user/docs", []string{"/user/docs2/123"}, false},
 		{"sub-path with empty exclusion", "/user/docs", []string{""}, false},
+		{"ancestor of deeply nested exclusion", "/user", []string{"/user/docs/123"}, true},
+		{"root is ancestor of any exclusion", ".", []string{"logs/keep.log"}, true},
+		{"root with empty exclusion list", ".", []string{}, false},
+		{"intermediate dir of nested exclusion", "logs", []string{"logs/archive/keep.log"}, true},
+		{"sibling of nested exclusion", "data", []string{"logs/archive/keep.log"}, false},
+		{"same path as exclusion is not ancestor", "logs/keep.log", []string{"logs/keep.log"}, false},
+		{"glob segment in exclusion", "dir1", []string{"dir*/keep.log"}, true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -98,19 +98,18 @@ func (l *Local) Upload(_ context.Context, src, dst string, opts *UpDownOpts) (er
 		if e != nil {
 			return fmt.Errorf("failed to build relative path for %s: %w", match, err)
 		}
-		if isExcluded(relPath, exclude) {
+		// check source file info
+		srcInfo, err := os.Stat(match)
+		if err != nil {
+			return fmt.Errorf("failed to stat source file %s: %w", match, err)
+		}
+		if isExcluded(relPath, srcInfo.IsDir(), exclude) {
 			continue
 		}
 
 		destination := dst
 		if len(matches) > 1 {
 			destination = filepath.Join(dst, filepath.Base(match))
-		}
-
-		// check source file info
-		srcInfo, err := os.Stat(match)
-		if err != nil {
-			return fmt.Errorf("failed to stat source file %s: %w", match, err)
 		}
 
 		// check destination file info
@@ -196,7 +195,7 @@ func (l *Local) syncSrcToDst(ctx context.Context, src, dst string, excl []string
 		if err != nil {
 			return err
 		}
-		if isExcluded(relPath, excl) {
+		if isExcluded(relPath, info.IsDir(), excl) {
 			return nil
 		}
 
@@ -330,7 +329,7 @@ func (l *Local) deletePath(ctx context.Context, src string, excl []string) error
 			return nil
 		}
 
-		if isExcluded(relPath, excl) {
+		if isExcluded(relPath, info.IsDir(), excl) {
 			hasExclusion = true
 			if info.IsDir() {
 				return filepath.SkipDir
@@ -355,8 +354,10 @@ func (l *Local) deletePath(ctx context.Context, src string, excl []string) error
 		return err
 	}
 
-	// remove the whole directory if there are no actual exclusions
+	// remove the whole directory if there are no actual exclusions. warn first, a mistyped
+	// exclude pattern that matches nothing would otherwise delete the whole tree silently.
 	if !hasExclusion {
+		log.Printf("[WARN] no exclude pattern matched anything under %s, removing it entirely", src)
 		return os.RemoveAll(src)
 	}
 

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -98,13 +98,15 @@ func (l *Local) Upload(_ context.Context, src, dst string, opts *UpDownOpts) (er
 		if e != nil {
 			return fmt.Errorf("failed to build relative path for %s: %w", match, err)
 		}
-		// check source file info
-		srcInfo, err := os.Stat(match)
-		if err != nil {
-			return fmt.Errorf("failed to stat source file %s: %w", match, err)
-		}
-		if isExcluded(relPath, srcInfo.IsDir(), exclude) {
+		// check source file info; check exclusion before the stat error so an excluded broken symlink
+		// is skipped instead of failing the whole upload
+		srcInfo, statErr := os.Stat(match)
+		isDir := statErr == nil && srcInfo.IsDir()
+		if isExcluded(relPath, isDir, exclude) {
 			continue
+		}
+		if statErr != nil {
+			return fmt.Errorf("failed to stat source file %s: %w", match, statErr)
 		}
 
 		destination := dst

--- a/pkg/executor/local_test.go
+++ b/pkg/executor/local_test.go
@@ -752,6 +752,56 @@ func TestDeleteWithExclude(t *testing.T) {
 				"file1.txt",
 			},
 		},
+		{
+			name:  "successful delete with only nested exclusions",
+			isDir: true,
+			srcStructure: map[string]bool{
+				"file1.txt":             false,
+				"logs/archive/keep.log": false,
+				"logs/archive/drop.log": false,
+				"logs/other.log":        false,
+				"data/file2.txt":        false,
+			},
+			dstStructure: map[string]bool{
+				"logs/archive/keep.log": false,
+			},
+			recursive: true,
+			exclude: []string{
+				"logs/archive/keep.log",
+			},
+		},
+		{
+			name:  "successful delete with glob directory exclusion",
+			isDir: true,
+			srcStructure: map[string]bool{
+				"file1.txt":      false,
+				"dir1/keep.txt":  false,
+				"other/drop.txt": false,
+			},
+			dstStructure: map[string]bool{
+				"dir1/keep.txt": false,
+			},
+			recursive: true,
+			exclude: []string{
+				"dir*/*",
+			},
+		},
+		{
+			name:  "glob directory exclusion does not protect same-prefix file",
+			isDir: true,
+			srcStructure: map[string]bool{
+				"dir1/keep.txt": false, // directory contents protected by dir*/*
+				"dir9.txt":      false, // plain file matching the dir* glob prefix, must be deleted
+				"plain.txt":     false,
+			},
+			dstStructure: map[string]bool{
+				"dir1/keep.txt": false,
+			},
+			recursive: true,
+			exclude: []string{
+				"dir*/*",
+			},
+		},
 	}
 
 	initTestCase := func(tc testCase) (string, error) {

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -77,7 +77,7 @@ func (ex *Remote) Upload(ctx context.Context, local, remote string, opts *UpDown
 		if e != nil {
 			return fmt.Errorf("failed to build relative path for %s: %w", match, err)
 		}
-		if isExcluded(relPath, exclude) {
+		if isExcluded(relPath, false, exclude) { // upload operates on files, directory upload is unsupported
 			continue
 		}
 
@@ -228,7 +228,8 @@ func (ex *Remote) Delete(ctx context.Context, remoteFile string, opts *DeleteOpt
 		hasExclusion := false
 		walker := sftpClient.Walk(remoteFile)
 
-		var pathsToDelete []string
+		var pathsToDelete []string // paths to delete when some exclusion actually matched
+		var allPaths []string      // all walked paths, used when no exclusion matched
 		for walker.Step() {
 			if walker.Err() != nil {
 				continue
@@ -239,27 +240,36 @@ func (ex *Remote) Delete(ctx context.Context, remoteFile string, opts *DeleteOpt
 			if e != nil {
 				return e
 			}
+			isDir := walker.Stat().IsDir()
 
-			// skip parent directories of the excluded files
-			if walker.Stat().IsDir() && (relPath == "." || isExcludedSubPath(relPath, exclude)) {
+			if isDir && relPath == "." {
 				continue
 			}
 
-			if isExcluded(relPath, exclude) {
+			if isExcluded(relPath, isDir, exclude) {
 				hasExclusion = true
-				if walker.Stat().IsDir() {
+				if isDir {
 					walker.SkipDir()
 				}
 
 				continue
 			}
 
-			pathsToDelete = append(pathsToDelete, walker.Path())
+			allPaths = append(allPaths, path)
+
+			// skip parent directories of the excluded files, they should survive if the exclusion matches
+			if isDir && isExcludedSubPath(relPath, exclude) {
+				continue
+			}
+
+			pathsToDelete = append(pathsToDelete, path)
 		}
 
-		// there is no actual exclusions
+		// no exclusion matched anything, delete the whole tree including parent dirs of the excluded paths.
+		// warn first, a mistyped exclude pattern that matches nothing would otherwise delete the whole tree silently.
 		if !hasExclusion {
-			pathsToDelete = append([]string{remoteFile}, pathsToDelete...)
+			log.Printf("[WARN] no exclude pattern matched anything under %s, removing it entirely", remoteFile)
+			pathsToDelete = append([]string{remoteFile}, allPaths...)
 		}
 
 		// delete files and directories in reverse order
@@ -585,7 +595,7 @@ func (ex *Remote) getRemoteFilesProperties(ctx context.Context, dir string, excl
 				continue
 			}
 
-			if isExcluded(relPath, excl) {
+			if isExcluded(relPath, entry.IsDir(), excl) {
 				continue
 			}
 
@@ -617,7 +627,7 @@ func (ex *Remote) findUnmatchedFiles(local, remote map[string]fileProperties, ex
 		if localProps.IsDir {
 			continue // don't put directories to unmatched files, no need to upload them
 		}
-		if isExcluded(localPath, excl) {
+		if isExcluded(localPath, false, excl) { // directories are already skipped above
 			continue // don't put excluded files to unmatched files, no need to upload them
 		}
 		remoteProps, exists := remote[localPath]
@@ -657,7 +667,7 @@ func (ex *Remote) findMatchedFiles(remote string, excl []string) ([]string, erro
 		if e != nil {
 			return nil, fmt.Errorf("failed to build relative path for %s: %w", match, err)
 		}
-		if isExcluded(relPath, excl) {
+		if isExcluded(relPath, false, excl) { // download operates on files, directory download is unsupported
 			continue
 		}
 

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -77,8 +77,14 @@ func (ex *Remote) Upload(ctx context.Context, local, remote string, opts *UpDown
 		if e != nil {
 			return fmt.Errorf("failed to build relative path for %s: %w", match, err)
 		}
-		if isExcluded(relPath, false, exclude) { // upload operates on files, directory upload is unsupported
-			continue
+		// matches are local paths, stat them so directory excludes (e.g. "subdir/*") skip a matched directory
+		matchInfo, statErr := os.Stat(match)
+		isDir := statErr == nil && matchInfo.IsDir()
+		if isExcluded(relPath, isDir, exclude) {
+			continue // excluded, including a broken symlink we were told to exclude
+		}
+		if statErr != nil {
+			return fmt.Errorf("failed to stat source file %s: %w", match, statErr)
 		}
 
 		remoteFile := remote
@@ -266,9 +272,12 @@ func (ex *Remote) Delete(ctx context.Context, remoteFile string, opts *DeleteOpt
 		}
 
 		// no exclusion matched anything, delete the whole tree including parent dirs of the excluded paths.
-		// warn first, a mistyped exclude pattern that matches nothing would otherwise delete the whole tree silently.
+		// warn only when excludes were actually provided, a mistyped pattern that matches nothing would
+		// otherwise delete the whole tree silently; an exclude-free delete (e.g. temp-dir cleanup) is normal.
 		if !hasExclusion {
-			log.Printf("[WARN] no exclude pattern matched anything under %s, removing it entirely", remoteFile)
+			if len(exclude) > 0 {
+				log.Printf("[WARN] no exclude pattern matched anything under %s, removing it entirely", remoteFile)
+			}
 			pathsToDelete = append([]string{remoteFile}, allPaths...)
 		}
 
@@ -667,8 +676,14 @@ func (ex *Remote) findMatchedFiles(remote string, excl []string) ([]string, erro
 		if e != nil {
 			return nil, fmt.Errorf("failed to build relative path for %s: %w", match, err)
 		}
-		if isExcluded(relPath, false, excl) { // download operates on files, directory download is unsupported
+		// matches are remote paths, stat them so directory excludes (e.g. "subdir/*") skip a matched directory
+		matchInfo, statErr := sftpClient.Stat(match)
+		isDir := statErr == nil && matchInfo.IsDir()
+		if isExcluded(relPath, isDir, excl) {
 			continue
+		}
+		if statErr != nil {
+			return nil, fmt.Errorf("failed to stat remote file %s: %w", match, statErr)
 		}
 
 		files = append(files, match)

--- a/pkg/executor/remote_test.go
+++ b/pkg/executor/remote_test.go
@@ -162,6 +162,33 @@ func TestExecuter_UploadGlobAndDownload(t *testing.T) {
 	}
 }
 
+func TestExecuter_UploadGlobExcludeDirectory(t *testing.T) {
+	ctx := context.Background()
+	hostAndPort, teardown := startTestContainer(t)
+	defer teardown()
+
+	c, err := NewConnector("testdata/test_ssh_key", time.Second*10, MakeLogs(true, false, nil))
+	require.NoError(t, err)
+	sess, err := c.Connect(ctx, hostAndPort, "h1", "test")
+	require.NoError(t, err)
+	defer sess.Close()
+
+	// local source with a file and a subdirectory; the glob matches both
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "keep.txt"), []byte("keep"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "subdir", "inner.txt"), []byte("inner"), 0o644))
+
+	// excluding the matched directory must skip it instead of feeding it into sftpUpload and failing
+	err = sess.Upload(ctx, filepath.Join(srcDir, "*"), "/tmp/globex", &UpDownOpts{Mkdir: true, Exclude: []string{"subdir/*"}})
+	require.NoError(t, err)
+
+	out, e := sess.Run(ctx, "ls -1 /tmp/globex", &RunOpts{Verbose: true})
+	require.NoError(t, e)
+	assert.Contains(t, out, "keep.txt", out)
+	assert.NotContains(t, out, "subdir", "excluded directory should not be uploaded")
+}
+
 func TestExecuter_Upload_FailedSourceNotFound(t *testing.T) {
 	ctx := t.Context()
 	hostAndPort, teardown := startTestContainer(t)
@@ -496,6 +523,20 @@ func TestExecuter_Delete(t *testing.T) {
 		assert.NotContains(t, out, "empty", out)
 	})
 
+	t.Run("delete dir recursive without exclude does not warn", func(t *testing.T) {
+		_, err = sess.Run(ctx, "mkdir -p /tmp/nowarn/sub && touch /tmp/nowarn/a /tmp/nowarn/sub/b", &RunOpts{Verbose: true})
+		require.NoError(t, err)
+
+		buff := bytes.NewBuffer(nil)
+		log.SetOutput(buff)
+		defer log.SetOutput(os.Stderr)
+
+		err = sess.Delete(ctx, "/tmp/nowarn", &DeleteOpts{Recursive: true})
+		require.NoError(t, err)
+		assert.NotContains(t, buff.String(), "no exclude pattern matched",
+			"exclude-free recursive delete should not warn")
+	})
+
 	t.Run("delete no-such-file", func(t *testing.T) {
 		err = sess.Delete(ctx, "/tmp/sync.dest/no-such-file", nil)
 		assert.NoError(t, err)
@@ -545,6 +586,22 @@ func TestExecuter_DeleteWithExclude(t *testing.T) {
 		require.NoError(t, e)
 		assert.Contains(t, out, "file21.txt", out)
 		assert.NotContains(t, out, "file22.txt", out)
+	})
+
+	t.Run("exclude matching nothing warns and removes tree", func(t *testing.T) {
+		_, err = sess.Run(ctx, "mkdir -p /tmp/warn.dest && touch /tmp/warn.dest/a /tmp/warn.dest/b", &RunOpts{Verbose: true})
+		require.NoError(t, err)
+
+		buff := bytes.NewBuffer(nil)
+		log.SetOutput(buff)
+		defer log.SetOutput(os.Stderr)
+
+		err = sess.Delete(ctx, "/tmp/warn.dest", &DeleteOpts{Recursive: true, Exclude: []string{"no-such-file"}})
+		require.NoError(t, err)
+		assert.Contains(t, buff.String(), "no exclude pattern matched", "a non-matching exclude should warn")
+		out, e := sess.Run(ctx, "ls -1 /tmp/", &RunOpts{Verbose: true})
+		require.NoError(t, e)
+		assert.NotContains(t, out, "warn.dest", "tree should be removed when exclude matches nothing")
 	})
 }
 

--- a/pkg/runner/commands.go
+++ b/pkg/runner/commands.go
@@ -401,14 +401,36 @@ func (ec *execCmd) Msync(ctx context.Context) (resp execCmdResp, err error) {
 	return resp, nil
 }
 
+// checkDeleteExclude validates the exclude option against the other delete flags for the given location.
+// Exclude requires a recursive delete (it filters directory contents) and cannot be combined with sudo,
+// as sudo deletion runs a plain rm that cannot apply exclusion patterns. Returns an error naming the
+// offending location, or nil if the combination is valid.
+func (ec *execCmd) checkDeleteExclude(loc string, del config.DeleteInternal) error {
+	if len(del.Exclude) == 0 {
+		return nil
+	}
+	if !del.Recursive {
+		return ec.errorFmt("delete with exclude requires recursive delete (recur: true) for %q", loc)
+	}
+	if ec.cmd.Options.Sudo {
+		return ec.errorFmt("delete with exclude is not supported with sudo for %q", loc)
+	}
+	return nil
+}
+
 // Delete deletes files on a target host. If sudo option is set, it will execute a sudo rm commands.
 func (ec *execCmd) Delete(ctx context.Context) (resp execCmdResp, err error) {
 	tmpl := templater{hostAddr: ec.hostAddr, hostName: ec.hostName, task: ec.tsk, command: ec.cmd.Name, env: ec.cmd.Environment}
 	loc := tmpl.apply(ec.cmd.Delete.Location)
 
+	if e := ec.checkDeleteExclude(loc, ec.cmd.Delete); e != nil {
+		return resp, e
+	}
+
 	if !ec.cmd.Options.Sudo {
 		// if sudo is not set, we can delete the file directly
-		if err := ec.exec.Delete(ctx, loc, &executor.DeleteOpts{Recursive: ec.cmd.Delete.Recursive}); err != nil {
+		opts := &executor.DeleteOpts{Recursive: ec.cmd.Delete.Recursive, Exclude: ec.cmd.Delete.Exclude}
+		if err := ec.exec.Delete(ctx, loc, opts); err != nil {
 			return resp, ec.errorFmt("can't delete files on %s: %w", ec.hostAddr, err)
 		}
 		resp.details = fmt.Sprintf(" {delete: %s, recursive: %v}", loc, ec.cmd.Delete.Recursive)
@@ -434,10 +456,18 @@ func (ec *execCmd) Delete(ctx context.Context) (resp execCmdResp, err error) {
 func (ec *execCmd) MDelete(ctx context.Context) (resp execCmdResp, err error) {
 	msgs := []string{}
 	tmpl := templater{hostAddr: ec.hostAddr, hostName: ec.hostName, task: ec.tsk, command: ec.cmd.Name, env: ec.cmd.Environment}
+
+	// validate all locations upfront, before any of them is deleted
+	for _, c := range ec.cmd.MDelete {
+		if e := ec.checkDeleteExclude(tmpl.apply(c.Location), c); e != nil {
+			return resp, e
+		}
+	}
+
 	for _, c := range ec.cmd.MDelete {
 		loc := tmpl.apply(c.Location)
 		ecSingle := ec
-		ecSingle.cmd.Delete = config.DeleteInternal{Location: loc, Recursive: c.Recursive}
+		ecSingle.cmd.Delete = config.DeleteInternal{Location: loc, Recursive: c.Recursive, Exclude: c.Exclude}
 		if _, err := ecSingle.Delete(ctx); err != nil {
 			return resp, ec.errorFmt("can't delete %s on %s: %w", loc, ec.hostAddr, err)
 		}
@@ -459,8 +489,11 @@ func (ec *execCmd) Wait(ctx context.Context) (resp execCmdResp, err error) {
 		if teardown == nil {
 			return
 		}
-		if err = teardown(); err != nil {
-			log.Printf("[WARN] can't teardown script on %s: %v", ec.hostAddr, err)
+		if tErr := teardown(); tErr != nil {
+			log.Printf("[WARN] can't teardown script on %s: %v", ec.hostAddr, tErr)
+			if err == nil { // don't overwrite the primary error with teardown error
+				err = ec.error(tErr)
+			}
 		}
 	}()
 

--- a/pkg/runner/commands_test.go
+++ b/pkg/runner/commands_test.go
@@ -455,6 +455,13 @@ func Test_execCmd(t *testing.T) {
 		require.EqualError(t, err, "timeout exceeded")
 	})
 
+	t.Run("wait multiline failed", func(t *testing.T) {
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Wait: config.WaitInternal{
+			Command: "echo this is wait\ncat /tmp/wait.never-done", Timeout: 1 * time.Second, CheckDuration: time.Millisecond * 100}}}
+		_, err := ec.Wait(ctx)
+		require.EqualError(t, err, "timeout exceeded")
+	})
+
 	t.Run("wait failed with sudo", func(t *testing.T) {
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Wait: config.WaitInternal{
 			Command: "cat /srv/wait.never-done", Timeout: 1 * time.Second, CheckDuration: time.Millisecond * 100},
@@ -504,6 +511,78 @@ func Test_execCmd(t *testing.T) {
 
 		_, err = sess.Run(ctx, "ls /tmp/delete-recursive", &executor.RunOpts{Verbose: true})
 		require.Error(t, err, "should not exist")
+	})
+
+	t.Run("delete files recursive with exclude", func(t *testing.T) {
+		var err error
+		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-exclude/keep", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err)
+		_, err = sess.Run(ctx, "touch /tmp/delete-exclude/delete1.me /tmp/delete-exclude/keep/keep.me", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err)
+
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
+			Location: "/tmp/delete-exclude", Recursive: true, Exclude: []string{"keep/keep.me"}}}}
+
+		_, err = ec.Delete(ctx)
+		require.NoError(t, err)
+
+		_, err = sess.Run(ctx, "ls /tmp/delete-exclude/delete1.me", &executor.RunOpts{Verbose: true})
+		require.Error(t, err, "should be deleted")
+		_, err = sess.Run(ctx, "ls /tmp/delete-exclude/keep/keep.me", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err, "excluded file should survive")
+	})
+
+	t.Run("delete with exclude and sudo rejected", func(t *testing.T) {
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
+			Location: "/srv/delete-exclude", Recursive: true, Exclude: []string{"keep.me"}},
+			Options: config.CmdOptions{Sudo: true}}}
+		_, err := ec.Delete(ctx)
+		require.ErrorContains(t, err, "not supported with sudo")
+		require.ErrorContains(t, err, "/srv/delete-exclude", "error should name the offending location")
+	})
+
+	t.Run("delete with exclude without recur rejected", func(t *testing.T) {
+		_, err := sess.Run(ctx, "mkdir -p /tmp/delete-norecur", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err)
+		_, err = sess.Run(ctx, "touch /tmp/delete-norecur/keep.me", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err)
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
+			Location: "/tmp/delete-norecur", Exclude: []string{"keep.me"}}}}
+		_, err = ec.Delete(ctx)
+		require.ErrorContains(t, err, "requires recursive")
+		require.ErrorContains(t, err, "/tmp/delete-norecur", "error should name the offending location")
+		_, err = sess.Run(ctx, "ls /tmp/delete-norecur/keep.me", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err, "nothing should be deleted when validation fails")
+	})
+
+	t.Run("delete files recursive with non-matching nested exclude", func(t *testing.T) {
+		var err error
+		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-exclude2/logs/archive", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err)
+		_, err = sess.Run(ctx, "touch /tmp/delete-exclude2/logs/archive/drop.log", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err)
+
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
+			Location: "/tmp/delete-exclude2", Recursive: true, Exclude: []string{"logs/archive/keep.log"}}}}
+
+		_, err = ec.Delete(ctx)
+		require.NoError(t, err)
+
+		_, err = sess.Run(ctx, "ls /tmp/delete-exclude2", &executor.RunOpts{Verbose: true})
+		require.Error(t, err, "directory should be fully removed when exclusion matches nothing")
+	})
+
+	t.Run("mdelete with exclude and sudo rejected before deleting", func(t *testing.T) {
+		_, err := sess.Run(ctx, "touch /tmp/mdelete-first.me", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err)
+		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{MDelete: []config.DeleteInternal{
+			{Location: "/tmp/mdelete-first.me"}, {Location: "/tmp/whatever", Recursive: true, Exclude: []string{"keep.me"}}},
+			Options: config.CmdOptions{Sudo: true}}}
+		_, err = ec.MDelete(ctx)
+		require.ErrorContains(t, err, "not supported with sudo")
+		require.ErrorContains(t, err, "/tmp/whatever", "error should name the offending location")
+		_, err = sess.Run(ctx, "ls /tmp/mdelete-first.me", &executor.RunOpts{Verbose: true})
+		require.NoError(t, err, "first location should not be deleted")
 	})
 
 	t.Run("delete file with sudo", func(t *testing.T) {

--- a/site/docs-src/index.md
+++ b/site/docs-src/index.md
@@ -436,7 +436,14 @@ Deletes a file or directory on the remote host(s), optionally can remove recursi
   delete: {"path": "/tmp/things", "recur": true, "exclude": ["*.txt", "*.yml"]}
 ```
 
-Delete also supports a list format to remove multiple paths at once. Note: `exclude` cannot be combined with the `sudo` option, as sudo deletion is performed with a plain shell command that cannot honour exclusion patterns.
+Delete also supports a list format to remove multiple paths at once.
+
+Notes on `exclude`:
+- It requires `recur: true`, as it filters the contents of a directory tree.
+- It cannot be combined with the `sudo` option, as sudo deletion is performed with a plain shell command that cannot apply exclusion patterns.
+- Patterns are matched with forward slashes on all platforms; a backslash is treated as a path separator, so it cannot be used to escape glob metacharacters.
+- A pattern ending in `/*` (e.g. `logs/*` or `data*/*`) also protects the matching directory itself, keeping it and its contents.
+- If no pattern matches anything, the whole tree is removed (a mistyped pattern will not silently preserve files); a `[WARN]` is logged in that case.
 
 #### `wait`
 

--- a/site/docs-src/index.md
+++ b/site/docs-src/index.md
@@ -436,7 +436,7 @@ Deletes a file or directory on the remote host(s), optionally can remove recursi
   delete: {"path": "/tmp/things", "recur": true, "exclude": ["*.txt", "*.yml"]}
 ```
 
-Delete also supports a list format to remove multiple paths at once.
+Delete also supports a list format to remove multiple paths at once. Note: `exclude` cannot be combined with the `sudo` option, as sudo deletion is performed with a plain shell command that cannot honour exclusion patterns.
 
 #### `wait`
 
@@ -507,6 +507,7 @@ The same options can be set for the whole task as well. In this case, the option
 
 ```yaml
   - name: deploy-things
+    tags: ["deploy"]                                          # tags for task filtering via -n flag
     on_error: "curl -s localhost:8080/error?msg={SPOT_ERROR}" # call hook on error
     options: {ignore_errors: true, no_auto: true, only_on: [host1, host2]}
     commands:


### PR DESCRIPTION
**Multiline `wait` swallowed its error**

Previously, a multiline `wait` command that timed out was reported as successful whenever the remote temp-dir cleanup succeeded: the teardown defer assigned its result to the named return unconditionally, overwriting the timeout error with nil (single-line waits were unaffected as they have no teardown). The defer now only surfaces the teardown error when there is no primary error, mirroring `Script`. A new `wait multiline failed` test fails on the old code and passes now.

**`delete` ignored documented `exclude` patterns**

Previously, the runner dropped the `exclude` field of `delete`/`mdelete` commands and passed only `recur` to the executor, so files the playbook asked to keep were deleted. Wiring it through surfaced several latent executor issues, all fixed here:

- `isExcludedSubPath` only protected the immediate parent directory of an excluded path, so exclusions nested deeper than one level were removed together with their ancestor directory; it now protects any ancestor of an excluded path.
- Remote recursive delete failed when an exclusion pattern matched nothing, leaving skipped ancestor directories behind and then erroring on the non-empty root; it now removes the whole tree when no exclusion actually matched, same as the local executor.
- Glob directory patterns like `dir*/*` matched the files inside but not the directory itself, so local delete removed the whole directory before visiting the excluded children; the directory rule is now glob-aware.
- Exclusion matching now uses forward-slash semantics on all platforms, so documented `/`-separated patterns also work with Windows local paths.

The `sudo` + `exclude` combination is rejected with an explicit error (for `mdelete` before any location is deleted), since sudo deletion runs a plain `rm` that cannot apply exclusion patterns; README notes this limitation.

Known cosmetic limitation: when an exclusion pattern of a mixed set matches nothing (or a wildcard pattern like `*/keep.log` matches only some directories), empty ancestor directories can be left behind. No data is lost or wrongly deleted in these cases.

Split out of #350.