### PR TITLE
Fix filepath.Rel error wrap to include the actual error

### DIFF
--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -96,7 +96,7 @@ func (l *Local) Upload(_ context.Context, src, dst string, opts *UpDownOpts) (er
 	for _, match := range matches {
 		relPath, e := filepath.Rel(filepath.Dir(src), match)
 		if e != nil {
-			return fmt.Errorf("failed to build relative path for %s: %w", match, err)
+			return fmt.Errorf("failed to build relative path for %s: %w", match, e)
 		}
 		// check source file info; check exclusion before the stat error so an excluded broken symlink
 		// is skipped instead of failing the whole upload

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -75,7 +75,7 @@ func (ex *Remote) Upload(ctx context.Context, local, remote string, opts *UpDown
 	for _, match := range matches {
 		relPath, e := filepath.Rel(filepath.Dir(local), match)
 		if e != nil {
-			return fmt.Errorf("failed to build relative path for %s: %w", match, err)
+			return fmt.Errorf("failed to build relative path for %s: %w", match, e)
 		}
 		// matches are local paths, stat them so directory excludes (e.g. "subdir/*") skip a matched directory
 		matchInfo, statErr := os.Stat(match)
@@ -674,7 +674,7 @@ func (ex *Remote) findMatchedFiles(remote string, excl []string) ([]string, erro
 	for _, match := range matches {
 		relPath, e := filepath.Rel(filepath.Dir(remote), match)
 		if e != nil {
-			return nil, fmt.Errorf("failed to build relative path for %s: %w", match, err)
+			return nil, fmt.Errorf("failed to build relative path for %s: %w", match, e)
 		}
 		// matches are remote paths, stat them so directory excludes (e.g. "subdir/*") skip a matched directory
 		matchInfo, statErr := sftpClient.Stat(match)


### PR DESCRIPTION
Follow-up to review feedback on #352.

The glob loops in `Local.Upload`, `Remote.Upload` and `findMatchedFiles` wrapped the outer `err` (nil at that point) instead of the local `e` returned by `filepath.Rel`, so a rel failure would render `%!w(<nil>)` and lose the cause. Three spots: `local.go:99`, `remote.go:78`, `remote.go:677`.

Diagnostic-only, no behaviour change. Triggering a `filepath.Rel` failure requires contrived absolute/relative path mixing not reachable through the glob API, so no dedicated test; the existing executor suite stays green.