### PR TITLE
config: fix inline comment stripping and simplified-playbook options

### DIFF
--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -179,13 +179,30 @@ func (cmd *Cmd) scriptCommand(inp string) string {
 		if len(c) < 2 {
 			continue
 		}
-		if i := strings.Index(c, "#"); i > 0 {
-			c = strings.TrimSpace(c[:i])
-		}
+		c = strings.TrimSpace(cmd.stripTrailingComment(c))
 		parts = append(parts, c)
 	}
 	res += strings.Join(parts, "; ") + "'"
 	return res
+}
+
+// stripTrailingComment removes a trailing shell comment from a single line so the lines can be
+// joined with "; " without the comment swallowing the next command. A '#' starts a comment only
+// at the beginning of a word (preceded by whitespace) and outside quotes, so '#' inside a token
+// such as ${VAR#prefix} or inside a quoted string like "fix #1" is preserved.
+func (cmd *Cmd) stripTrailingComment(s string) string {
+	var inSingle, inDouble bool
+	for i := 0; i < len(s); i++ {
+		switch ch := s[i]; {
+		case ch == '\'' && !inDouble:
+			inSingle = !inSingle
+		case ch == '"' && !inSingle:
+			inDouble = !inDouble
+		case ch == '#' && !inSingle && !inDouble && i > 0 && (s[i-1] == ' ' || s[i-1] == '\t'):
+			return s[:i]
+		}
+	}
+	return s
 }
 
 // scriptFile returns a reader for script file. All the lines in the command used as a script, with hashbang,

--- a/pkg/config/command_test.go
+++ b/pkg/config/command_test.go
@@ -279,6 +279,27 @@ func TestCmd_getScriptCommand(t *testing.T) {
 	})
 }
 
+func TestCmd_scriptCommandComments(t *testing.T) {
+	tbl := []struct {
+		name   string
+		script string
+		expect string
+	}{
+		{"trailing comment stripped", "echo hi # a greeting", `/bin/sh -c 'echo hi'`},
+		{"param expansion preserved", "echo ${VAR#prefix}", `/bin/sh -c 'echo ${VAR#prefix}'`},
+		{"double-quoted hash kept in token", `git commit -m "fix #1"`, `/bin/sh -c 'git commit -m "fix #1"'`},
+		{"single-quoted hash kept in assembled string", `echo 'a # b'`, `/bin/sh -c 'echo 'a # b''`},
+		{"mid-token hash preserved", "printf a#b", `/bin/sh -c 'printf a#b'`},
+		{"multiline comment does not swallow next", "echo a # c\necho b", `/bin/sh -c 'echo a; echo b'`},
+	}
+	cmd := &Cmd{}
+	for _, tc := range tbl {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, cmd.scriptCommand(tc.script))
+		})
+	}
+}
+
 func TestCmd_getScriptCommandCustomShell(t *testing.T) {
 	c, err := New("testdata/f1.yml", &Overrides{SSHShell: "/bin/bash"}, nil)
 	require.NoError(t, err)

--- a/pkg/config/playbook.go
+++ b/pkg/config/playbook.go
@@ -275,10 +275,18 @@ func unmarshalPlaybookFile(fname string, data []byte, overrides *Overrides, res 
 
 	simple := &SimplePlayBook{}
 	if err := unmarshal(data, simple, false); err == nil && len(simple.Task) > 0 {
-		// success, this is SimplePlayBook config, convert it to full PlayBook config
+		// success, this is SimplePlayBook config, convert it to full PlayBook config.
+		// copy the top-level fields explicitly instead of relying on the partial decode of the failed
+		// full-parse attempt above, which is fragile and undefined for the toml path
 		res.Inventory = simple.Inventory
-		res.Tasks = []Task{{Commands: simple.Task}} // simple playbook has just a list of commands as the task
-		res.Tasks[0].Name = "default"               // we have only one task, set it as default
+		res.User = simple.User
+		res.SSHKey = simple.SSHKey
+		res.SSHShell = simple.SSHShell
+		res.SSHTempDir = simple.SSHTempDir
+		res.LocalShell = simple.LocalShell
+		// simple playbook is a single task; carry its options so they propagate to all commands
+		res.Tasks = []Task{{Commands: simple.Task, Options: simple.Options}}
+		res.Tasks[0].Name = "default" // we have only one task, set it as default
 
 		hasInventory := simple.Inventory != "" || (overrides != nil && overrides.Inventory != "") || os.Getenv(inventoryEnv) != ""
 

--- a/pkg/config/playbook_test.go
+++ b/pkg/config/playbook_test.go
@@ -162,6 +162,42 @@ func TestPlaybook_New(t *testing.T) {
 		assert.Equal(t, []Destination{{Host: "127.0.0.1", Port: 2222}}, c.Targets["default"].Hosts)
 	})
 
+	assertSimpleOptions := func(t *testing.T, c *PlayBook) {
+		t.Helper()
+		require.Len(t, c.Tasks, 1, "1 task")
+		require.Len(t, c.Tasks[0].Commands, 2, "2 commands")
+		assert.Equal(t, "deploy", c.User, "top-level user carried through")
+		assert.Equal(t, "/keys/id_rsa", c.SSHKey, "top-level ssh_key carried through")
+		for _, cmd := range c.Tasks[0].Commands {
+			assert.True(t, cmd.Options.Sudo, "sudo propagated to %q", cmd.Name)
+			assert.True(t, cmd.Options.IgnoreErrors, "ignore_errors propagated to %q", cmd.Name)
+			assert.Equal(t, "/bin/bash", cmd.SSHShell, "ssh_shell carried through to %q", cmd.Name)
+			assert.Equal(t, "/var/tmp", cmd.SSHTempDir, "ssh_temp carried through to %q", cmd.Name)
+			assert.Equal(t, "/bin/zsh", cmd.LocalShell, "local_shell carried through to %q", cmd.Name)
+		}
+	}
+
+	t.Run("simple playbook with top-level options and shell fields (yaml)", func(t *testing.T) {
+		c, err := New("testdata/simple-playbook-options.yml", nil, nil)
+		require.NoError(t, err)
+		assertSimpleOptions(t, c)
+	})
+
+	t.Run("simple playbook with top-level options and shell fields (toml)", func(t *testing.T) {
+		c, err := New("testdata/simple-playbook-options.toml", nil, nil)
+		require.NoError(t, err)
+		assertSimpleOptions(t, c)
+	})
+
+	t.Run("simple playbook overrides still win over copied top-level values", func(t *testing.T) {
+		c, err := New("testdata/simple-playbook-options.yml", &Overrides{SSHShell: "/bin/dash"}, nil)
+		require.NoError(t, err)
+		require.Len(t, c.Tasks, 1)
+		for _, cmd := range c.Tasks[0].Commands {
+			assert.Equal(t, "/bin/dash", cmd.SSHShell, "override ssh_shell should win over the playbook value")
+		}
+	})
+
 	t.Run("playbook with secrets", func(t *testing.T) {
 		secProvider := &mocks.SecretsProviderMock{
 			GetFunc: func(key string) (string, error) {

--- a/pkg/config/testdata/simple-playbook-options.toml
+++ b/pkg/config/testdata/simple-playbook-options.toml
@@ -1,0 +1,19 @@
+user = "deploy"
+ssh_key = "/keys/id_rsa"
+ssh_shell = "/bin/bash"
+ssh_temp = "/var/tmp"
+local_shell = "/bin/zsh"
+
+targets = ["127.0.0.1:2222"]
+
+[options]
+sudo = true
+ignore_errors = true
+
+[[task]]
+name = "one"
+script = "echo hello"
+
+[[task]]
+name = "two"
+script = "echo world"

--- a/pkg/config/testdata/simple-playbook-options.yml
+++ b/pkg/config/testdata/simple-playbook-options.yml
@@ -1,0 +1,16 @@
+user: deploy
+ssh_key: /keys/id_rsa
+ssh_shell: /bin/bash
+ssh_temp: /var/tmp
+local_shell: /bin/zsh
+
+targets: ["127.0.0.1:2222"]
+
+options: {sudo: true, ignore_errors: true}
+
+task:
+  - name: one
+    script: echo hello
+
+  - name: two
+    script: echo world


### PR DESCRIPTION
Two config-parsing correctness fixes found during review.

**Single-line comment stripping**

`scriptCommand` stripped a single-line script from the first `#` anywhere in the line, which mangled a `#` inside a token (e.g. `${VAR#prefix}`) or inside a quoted string (e.g. `git commit -m "fix #1"`). Comment stripping is still needed so lines joined with `; ` don't have a trailing comment swallow the next command, so it now strips only a real trailing shell comment: a `#` that starts a word (preceded by whitespace) and is outside single/double quotes. Escapes are not handled (acceptable for this use).

**Simplified-playbook options dropped**

The simplified-playbook conversion never transferred the top-level `options:` block to the generated task, so those options were silently ignored on every command. It also relied on the fragile partial decode of the failed strict full-parse for the `user`/`ssh_key`/shell fields. It now carries `options` into the generated task (the existing propagation loop in `New` applies them to all commands) and copies `user`, `ssh_key`, `ssh_shell`, `ssh_temp` and `local_shell` into the playbook explicitly.

Both covered by new tests (comment table incl. `${VAR#…}`/quoted-`#`; a simplified playbook with top-level options + shell fields), each negative-checked against the old code.