### PR TITLE
docs, schema and build/CI hygiene fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
       - name: import gpg key
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import
-        env:
-          GPG_TTY: $(tty)
 
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,9 +55,6 @@ linters:
           - staticcheck
         text: at least one file in a package should have a package comment
       - linters:
-          - golint
-        text: should have a package comment, unless it's in another file for this package
-      - linters:
           - gosec
         text: integer overflow conversion
       - linters:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ gofmt -s -w $(find . -type f -name "*.go" -not -path "./vendor/*") && go generat
 - AWS SDK: `github.com/aws/aws-sdk-go-v2/*` (for AWS Secrets Manager)
 - Vault: `github.com/hashicorp/vault/api` (for HashiCorp Vault integration)
 - Container testing: `github.com/testcontainers/testcontainers-go`
-- Encryption: `golang.org/x/crypto/scrypt` and `crypto/aes`
+- Encryption: `golang.org/x/crypto/argon2` (key derivation) and `golang.org/x/crypto/nacl/secretbox`
 
 ## Code Style Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 
 release:
 	@echo release to .bin
-	goreleaser --snapshot --skip-publish --clean
+	goreleaser --snapshot --skip=publish --clean
 	ls -l .bin
 
 test:

--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ Spot supports the following command-line options:
 - `--ssh-agent`: Enables using the SSH agent for authentication. Defaults to `false`. Users can also set the environment variable `SPOT_SSH_AGENT` to define the value.
 - `--forward-ssh-agent`: Enables forwarding of connections from an authentication agent. Defaults to `false`. Users can also set the environment variable `SPOT_FORWARD_SSH_AGENT` to define the value.
 - `--shell` - shell for remote ssh execution, default is `/bin/sh`. Users can also set the environment variable `SPOT_SHELL` to define the value.  
-- `--local-shell` - shell for local execution, default is os shell. Users can also set the environment variable `SPOT_LOCAL_SHELL` to define the value.
-- `--temp` - temporary directory for remote execution, default is `/tmp`. Users can also set the environment variable `SPOT_TEMP_DIR` to define the value.
+- `--temp` - temporary directory for remote execution, default is `/tmp`. Users can also set the environment variable `SPOT_TEMP` to define the value.
 - `-i`, `--inventory=`: Specifies the inventory file or URL to use for the task execution. Overrides the inventory file defined in the
   playbook file. Users can also set the environment variable `$SPOT_INVENTORY` to define the default inventory file path or url.
 - `-u`, `--user=`: Specifies the SSH user to use when connecting to remote hosts. Overrides the user defined in the playbook file .
@@ -981,7 +980,7 @@ tasks:
           ls -laR /tmp/${SPOT_COMMAND}
         env: { FOO: bar, BAR: "{SPOT_COMMAND}-blah" }
       - name: delete things
-        delete: {"loc": "/tmp/things/{SPOT_REMOTE_USER}", "recur": true}
+        delete: {"path": "/tmp/things/{SPOT_REMOTE_USER}", "recur": true}
 
 ```
 

--- a/pkg/secrets/spot.go
+++ b/pkg/secrets/spot.go
@@ -250,7 +250,7 @@ func (p *InternalProvider) decrypt(encodedData string) (string, error) {
 // and generates a derived key using the Argon2id key derivation function.
 // Argon2id is recommended for password hashing and provides a good balance between
 // security and performance. The function uses the following parameters:
-// - Time cost: 2 iterations, which increases the time required for key derivation.
+// - Time cost: 1 iteration, which increases the time required for key derivation.
 // - Memory cost: 64 MiB, which increases the memory required for key derivation.
 // - Parallelism: 4, which adjusts the number of threads used for key derivation.
 // - Key length: 32 bytes, which is the length of the derived key.

--- a/schemas/playbook.json
+++ b/schemas/playbook.json
@@ -6,11 +6,11 @@
   "type": "object",
   "anyOf": [
     {
-      "required": ["user", "task"],
+      "required": ["task"],
       "description": "Simplified playbook with single task"
     },
     {
-      "required": ["user", "tasks"],
+      "required": ["tasks"],
       "description": "Full playbook with multiple tasks"
     }
   ],
@@ -503,12 +503,12 @@
         },
         "timeout": {
           "type": "string",
-          "default": "30s",
+          "default": "24h",
           "description": "Maximum time to wait (e.g., '30s', '5m')"
         },
         "interval": {
           "type": "string",
-          "default": "1s",
+          "default": "5s",
           "description": "Time between checks (e.g., '1s', '5s')"
         }
       }

--- a/site/docs-src/index.md
+++ b/site/docs-src/index.md
@@ -136,8 +136,7 @@ Spot supports the following command-line options:
 - `--ssh-agent`: Enables using the SSH agent for authentication. Defaults to `false`. Users can also set the environment variable `SPOT_SSH_AGENT` to define the value.
 - `--forward-ssh-agent`: Enables forwarding of connections from an authentication agent. Defaults to `false`. Users can also set the environment variable `SPOT_FORWARD_SSH_AGENT` to define the value.
 - `--shell` - shell for remote ssh execution, default is `/bin/sh`. Users can also set the environment variable `SPOT_SHELL` to define the value.  
-- `--local-shell` - shell for local execution, default is os shell. Users can also set the environment variable `SPOT_LOCAL_SHELL` to define the value.
-- `--temp` - temporary directory for remote execution, default is `/tmp`. Users can also set the environment variable `SPOT_TEMP_DIR` to define the value.
+- `--temp` - temporary directory for remote execution, default is `/tmp`. Users can also set the environment variable `SPOT_TEMP` to define the value.
 - `-i`, `--inventory=`: Specifies the inventory file or URL to use for the task execution. Overrides the inventory file defined in the
   playbook file. Users can also set the environment variable `$SPOT_INVENTORY` to define the default inventory file path or url.
 - `-u`, `--user=`: Specifies the SSH user to use when connecting to remote hosts. Overrides the user defined in the playbook file .
@@ -981,7 +980,7 @@ tasks:
           ls -laR /tmp/${SPOT_COMMAND}
         env: { FOO: bar, BAR: "{SPOT_COMMAND}-blah" }
       - name: delete things
-        delete: {"loc": "/tmp/things/{SPOT_REMOTE_USER}", "recur": true}
+        delete: {"path": "/tmp/things/{SPOT_REMOTE_USER}", "recur": true}
 
 ```
 

--- a/site/docs/llms.txt
+++ b/site/docs/llms.txt
@@ -45,8 +45,7 @@ sudo apk add spot_v<VERSION>_linux_amd64.apk
     --ssh-agent          Use SSH agent (env: $SPOT_SSH_AGENT)
     --forward-ssh-agent  Forward SSH agent to remote (env: $SPOT_FORWARD_SSH_AGENT)
     --shell=PATH         Remote shell (default: /bin/sh, env: $SPOT_SHELL)
-    --local-shell=PATH   Local shell (default: OS shell, env: $SPOT_LOCAL_SHELL)
-    --temp=DIR           Remote temp directory (default: /tmp, env: $SPOT_TEMP_DIR)
+    --temp=DIR           Remote temp directory (default: /tmp, env: $SPOT_TEMP)
 -i, --inventory=FILE     Inventory file or URL (env: $SPOT_INVENTORY)
 -u, --user=USER          SSH user override
 -k, --key=PATH           SSH key override

--- a/spot.1
+++ b/spot.1
@@ -168,14 +168,9 @@ Users can also set the environment variable
 Users can also set the environment variable \f[CR]SPOT_SHELL\f[R] to
 define the value.
 .IP \(bu 2
-\f[CR]\-\-local\-shell\f[R] \- shell for local execution, default is os
-shell.
-Users can also set the environment variable \f[CR]SPOT_LOCAL_SHELL\f[R]
-to define the value.
-.IP \(bu 2
 \f[CR]\-\-temp\f[R] \- temporary directory for remote execution, default
 is \f[CR]/tmp\f[R].
-Users can also set the environment variable \f[CR]SPOT_TEMP_DIR\f[R] to
+Users can also set the environment variable \f[CR]SPOT_TEMP\f[R] to
 define the value.
 .IP \(bu 2
 \f[CR]\-i\f[R], \f[CR]\-\-inventory=\f[R]: Specifies the inventory file


### PR DESCRIPTION
A batch of documentation, schema and build/CI corrections found during review (no runtime code change except one godoc comment).

**Docs**
- README: drop the non-existent `--local-shell` / `SPOT_LOCAL_SHELL` flag (local shell is a playbook field only, there is no CLI flag/env); correct the `--temp` env var from `SPOT_TEMP_DIR` to `SPOT_TEMP`; fix the `delete` example key from `loc` to `path` (the field is `path`, and strict parsing rejects `loc`).
- Same `--local-shell`/`SPOT_TEMP_DIR` corrections applied to `site/docs/llms.txt` and `spot.1` (surgical edits, no full manpage regen), and `site/docs-src/index.md` regenerated from README.
- CLAUDE.md: encryption is `argon2` + `nacl/secretbox`, not `scrypt` + `aes`.
- `deriveKey` godoc: time cost is 1 iteration, matching `argon2.IDKey(..., 1, ...)`.

**Schema**
- `user` is optional (spot falls back to the OS user), so it is dropped from the required lists.
- `wait` defaults corrected to match the code: timeout `24h`, interval `5s`.

**Build / CI**
- Makefile: goreleaser v2 uses `--skip=publish`; the removed `--skip-publish` broke `make release`.
- .golangci.yml: drop the dead `golint` exclusion (golint is gone in golangci-lint v2).
- release.yml: drop `GPG_TTY: \$(tty)`, which is not shell-expanded and so was a literal no-op.