### PR TITLE
guards: decrypt length check, ssh user nil guard, command count across hosts

### DIFF
--- a/cmd/spot/main.go
+++ b/cmd/spot/main.go
@@ -505,8 +505,8 @@ func sshKey(sshAgent bool, sshKey string, pbook *config.PlayBook) (key string, e
 
 // get ssh user from cli or playbook. if no user is provided, use current user from os
 func sshUser(sshUser string, pbook *config.PlayBook) (string, error) {
-	if sshUser == "" && (pbook == nil || pbook.User != "") { // no user provided in cli
-		sshUser = pbook.User // use playbook's user
+	if sshUser == "" && pbook != nil && pbook.User != "" { // no user provided in cli, use playbook's user
+		sshUser = pbook.User
 	}
 	if sshUser == "" { // no user provided in cli or playbook
 		u, err := userProvider.Current()

--- a/cmd/spot/main_test.go
+++ b/cmd/spot/main_test.go
@@ -746,6 +746,25 @@ func Test_sshUserAndKey(t *testing.T) {
 	}
 }
 
+func Test_sshUserNilPlaybook(t *testing.T) {
+	t.Run("nil playbook, cli user wins", func(t *testing.T) {
+		var got string
+		var err error
+		assert.NotPanics(t, func() { got, err = sshUser("cliuser", nil) })
+		require.NoError(t, err)
+		assert.Equal(t, "cliuser", got)
+	})
+
+	t.Run("nil playbook without cli user falls back to os user", func(t *testing.T) {
+		orig := userProvider
+		defer func() { userProvider = orig }()
+		userProvider = &mockUserInfoProvider{user: &user.User{Username: "osuser"}}
+		got, err := sshUser("", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "osuser", got)
+	})
+}
+
 type mockUserInfoProvider struct {
 	user *user.User
 	err  error

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"text/template"
 	"time"
 
@@ -102,22 +101,21 @@ func (p *Process) Run(ctx context.Context, task, target string) (s ProcResp, err
 	}
 	log.Printf("[DEBUG] target hosts (%d) %+v", len(targetHosts), targetHosts)
 
-	var commands int32
+	maxCommands := 0
 	lock := sync.Mutex{}
 
 	wg := syncs.NewErrSizedGroup(p.Concurrency, syncs.Context(ctx), syncs.Preemptive)
-	for i, host := range targetHosts {
+	for _, host := range targetHosts {
 		wg.Go(func() error {
 			user := host.User // default user from target
 			if tsk.User != "" {
 				user = tsk.User // override user from task if any set
 			}
 			resp, e := p.runTaskOnHost(ctx, tsk, fmt.Sprintf("%s:%d", host.Host, host.Port), host.Name, user)
-			if i == 0 {
-				atomic.AddInt32(&commands, int32(resp.count))
-			}
 
 			lock.Lock()
+			// report the fullest run across hosts, since a host may skip or fail some commands
+			maxCommands = max(maxCommands, resp.count)
 			if e != nil {
 				errLog := p.Logs.WithHost(host.Host, host.Name).Err
 				errLog.Write([]byte(e.Error())) // nolint
@@ -138,7 +136,7 @@ func (p *Process) Run(ctx context.Context, task, target string) (s ProcResp, err
 
 	return ProcResp{
 		Hosts:      len(targetHosts),
-		Commands:   int(atomic.LoadInt32(&commands)),
+		Commands:   maxCommands,
 		Vars:       allVars,
 		Registered: allRegistered,
 	}, err

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1461,6 +1461,29 @@ func TestProcess_pickCmdExecutor(t *testing.T) {
 	})
 }
 
+func TestProcess_Run_CommandCountAcrossHosts(t *testing.T) {
+	// two local commands; the second only runs on host-b via only_on, so host-a runs 1 command and
+	// host-b runs 2. host-a is index 0, so the old host-0-only count would report 1 - the fix reports 2.
+	tsk := config.Task{Name: "t", Commands: []config.Cmd{
+		{Name: "c1", Script: "echo one", Options: config.CmdOptions{Local: true}},
+		{Name: "c2", Script: "echo two", Options: config.CmdOptions{Local: true, OnlyOn: []string{"host-b"}}},
+	}}
+	pbook := &mocks.PlaybookMock{
+		TaskFunc: func(string) (*config.Task, error) { return &tsk, nil },
+		TargetHostsFunc: func(string) ([]config.Destination, error) {
+			return []config.Destination{
+				{Host: "host-a", Name: "host-a", Port: 22},
+				{Host: "host-b", Name: "host-b", Port: 22},
+			}, nil
+		},
+	}
+	p := &Process{Concurrency: 1, Playbook: pbook, Logs: executor.MakeLogs(false, false, nil)}
+	res, err := p.Run(context.Background(), "t", "all")
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Hosts)
+	assert.Equal(t, 2, res.Commands, "should report the fuller host's command count, not host 0's")
+}
+
 func startTestContainer(t *testing.T) (hostAndPort string, teardown func()) {
 	return startTestContainerWithCustomUser(t, "test")
 }

--- a/pkg/secrets/spot.go
+++ b/pkg/secrets/spot.go
@@ -230,6 +230,9 @@ func (p *InternalProvider) decrypt(encodedData string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if len(sealed) < 40 { // 24-byte nonce + 16-byte salt, guard before slicing to avoid a panic
+		return "", errors.New("invalid ciphertext: too short")
+	}
 
 	nonce := new([24]byte)
 	copy(nonce[:], sealed[:24])

--- a/pkg/secrets/spot_test.go
+++ b/pkg/secrets/spot_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"testing"
@@ -32,6 +33,22 @@ func TestInternalProvider_EncryptionDecryption(t *testing.T) {
 		t.Logf("encrypted value: %s", er)
 		p.key = []byte("bad_key")
 		_, err = p.decrypt(er)
+		require.Error(t, err)
+	})
+
+	t.Run("short ciphertext returns error, not panic", func(t *testing.T) {
+		p := &InternalProvider{key: []byte("test_key")}
+		// valid base64 that decodes to fewer than 40 bytes (nonce+salt)
+		short := base64.StdEncoding.EncodeToString([]byte("too short"))
+		var err error
+		assert.NotPanics(t, func() { _, err = p.decrypt(short) })
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid ciphertext")
+	})
+
+	t.Run("invalid base64 returns error", func(t *testing.T) {
+		p := &InternalProvider{key: []byte("test_key")}
+		_, err := p.decrypt("not-valid-base64!!!")
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
Three small defensive-correctness fixes found during review.

- `decrypt` (pkg/secrets/spot.go) sliced `sealed[:24]`/`sealed[24:40]`/`sealed[40:]` with no bounds check, so a stored value that base64-decodes to fewer than 40 bytes (24-byte nonce + 16-byte salt) panicked. It now returns an error instead.
- `sshUser` (cmd/spot/main.go) had an inverted nil guard: `sshUser == "" && (pbook == nil || pbook.User != "")` entered the branch when `pbook` was nil and then dereferenced `pbook.User`. It now only uses the playbook user when `pbook != nil`.
- `ProcResp.Commands` (pkg/runner/runner.go) counted only host index 0, undercounting the summary when that host skips or fails commands the others run. It now reports the max command count across hosts, tracked under the existing lock (the `sync/atomic` import is no longer needed).

Each is covered by a test, negative-checked against the old code (the sshUser one reproduces the nil-panic). Full runner/secrets/cmd suites pass under -race.

Note: codex xhigh review could not complete in my environment (the background review process was repeatedly killed mid-run); this was self-reviewed against the tests above.