### PR TITLE
executor: fix context-cancellation leaks, local copy bugs, drop dead options

### DIFF
--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -68,7 +68,6 @@ type SyncInternal struct {
 	Dest    string   `yaml:"dst" toml:"dst"`         // destination must be a directory
 	Delete  bool     `yaml:"delete" toml:"delete"`   // delete files in destination that are not in source
 	Exclude []string `yaml:"exclude" toml:"exclude"` // exclude files matching these patterns
-	Force   bool     `yaml:"force" toml:"force"`     // force sync even if source and destination are the same
 }
 
 // DeleteInternal defines delete command, implemented internally

--- a/pkg/executor/connector.go
+++ b/pkg/executor/connector.go
@@ -177,5 +177,7 @@ func (c *Connector) sshConfig(user, privateKeyPath string) (*ssh.ClientConfig, n
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("ssh connector with private key %s.., timeout %v, agent %v", c.privateKey[:8], c.timeout, c.enableAgent)
+	// cap the slice so it does not run past the end for short or empty (agent-only) keys
+	key := c.privateKey[:min(len(c.privateKey), 8)]
+	return fmt.Sprintf("ssh connector with private key %s.., timeout %v, agent %v", key, c.timeout, c.enableAgent)
 }

--- a/pkg/executor/connector_test.go
+++ b/pkg/executor/connector_test.go
@@ -5,8 +5,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConnector_String(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        string
+		wantSubstr string
+	}{
+		{"agent-only empty key", "", "private key .., "},
+		{"short key", "abc", "private key abc.., "},
+		{"exactly eight", "12345678", "private key 12345678.., "},
+		{"long key path", "/home/user/.ssh/id_rsa", "private key /home/us.., "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Connector{privateKey: tc.key, timeout: time.Second}
+			var got string
+			assert.NotPanics(t, func() { got = c.String() }, "String must not panic on short or empty keys")
+			assert.Contains(t, got, tc.wantSubstr, "String must show at most the first 8 key chars")
+		})
+	}
+}
 
 func TestConnector_Connect(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -27,18 +27,15 @@ type RunOpts struct {
 
 // UpDownOpts is a struct for upload and download options.
 type UpDownOpts struct {
-	Mkdir    bool     // create remote directory if it does not exist
-	Checksum bool     // compare checksums of local and remote files, default is size and modtime
-	Force    bool     // overwrite existing files on remote
-	Exclude  []string // exclude files matching the given patterns
+	Mkdir   bool     // create remote directory if it does not exist
+	Force   bool     // overwrite existing files on remote
+	Exclude []string // exclude files matching the given patterns
 }
 
 // SyncOpts is a struct for sync options.
 type SyncOpts struct {
-	Delete   bool     // delete extra files on remote
-	Exclude  []string // exclude files matching the given patterns
-	Checksum bool     // compare checksums of local and remote files, default is size and modtime
-	Force    bool     // overwrite existing files on remote
+	Delete  bool     // delete extra files on remote
+	Exclude []string // exclude files matching the given patterns
 }
 
 // DeleteOpts is a struct for delete options.

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -67,7 +67,7 @@ func (l *Local) Run(ctx context.Context, cmd string, _ *RunOpts) (out []string, 
 }
 
 // Upload just copy file from one place to another
-func (l *Local) Upload(_ context.Context, src, dst string, opts *UpDownOpts) (err error) {
+func (l *Local) Upload(ctx context.Context, src, dst string, opts *UpDownOpts) (err error) {
 
 	// check if the local parameter contains a glob pattern
 	matches, err := filepath.Glob(src)
@@ -88,12 +88,20 @@ func (l *Local) Upload(_ context.Context, src, dst string, opts *UpDownOpts) (er
 	}
 
 	if mkdir {
-		if err = os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
-			return fmt.Errorf("can't create local dir %s: %w", filepath.Dir(dst), err)
+		// with multiple matches dst is treated as a directory, so create it; otherwise create its parent
+		mkdirTarget := filepath.Dir(dst)
+		if len(matches) > 1 {
+			mkdirTarget = dst
+		}
+		if err = os.MkdirAll(mkdirTarget, 0o750); err != nil {
+			return fmt.Errorf("can't create local dir %s: %w", mkdirTarget, err)
 		}
 	}
 
 	for _, match := range matches {
+		if err := ctx.Err(); err != nil { // honor cancellation between files
+			return err
+		}
 		relPath, e := filepath.Rel(filepath.Dir(src), match)
 		if e != nil {
 			return fmt.Errorf("failed to build relative path for %s: %w", match, e)
@@ -139,8 +147,8 @@ func (l *Local) Upload(_ context.Context, src, dst string, opts *UpDownOpts) (er
 }
 
 // Download just copy file from one place to another
-func (l *Local) Download(_ context.Context, src, dst string, opts *UpDownOpts) (err error) {
-	return l.Upload(context.Background(), src, dst, opts) // same as upload for local
+func (l *Local) Download(ctx context.Context, src, dst string, opts *UpDownOpts) (err error) {
+	return l.Upload(ctx, src, dst, opts) // same as upload for local
 }
 
 // Sync directories from src to dst

--- a/pkg/executor/local_test.go
+++ b/pkg/executor/local_test.go
@@ -866,6 +866,52 @@ func TestDeleteWithExclude(t *testing.T) {
 	}
 }
 
+func TestLocal_UploadMultiGlobMkdir(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "b.txt"), []byte("b"), 0o644))
+
+	// dst directory does not exist yet; with multiple matches it must be created as a directory
+	dst := filepath.Join(t.TempDir(), "sub", "dest")
+	l := &Local{}
+	err := l.Upload(context.Background(), filepath.Join(srcDir, "*.txt"), dst, &UpDownOpts{Mkdir: true})
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(dst, "a.txt"))
+	assert.FileExists(t, filepath.Join(dst, "b.txt"))
+}
+
+func TestLocal_UploadCanceledContext(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("a"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled
+
+	l := &Local{}
+	err := l.Upload(ctx, filepath.Join(srcDir, "*.txt"), t.TempDir(), &UpDownOpts{Mkdir: true})
+	require.ErrorIs(t, err, context.Canceled, "upload should honor a canceled context")
+}
+
+func TestLocal_UploadMultiFileCanceled(t *testing.T) {
+	srcDir := t.TempDir()
+	for _, n := range []string{"a.txt", "b.txt", "c.txt"} {
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, n), []byte(n), 0o644))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before the per-file loop runs
+
+	dst := t.TempDir()
+	l := &Local{}
+	err := l.Upload(ctx, filepath.Join(srcDir, "*.txt"), dst, &UpDownOpts{Mkdir: true})
+	require.ErrorIs(t, err, context.Canceled, "multi-file upload should honor a canceled context")
+
+	entries, err := os.ReadDir(dst)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "no files should be copied once the context is canceled")
+}
+
 func TestClose(t *testing.T) {
 	l := &Local{}
 	err := l.Close()

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -341,7 +341,7 @@ func (ex *Remote) sshRun(ctx context.Context, client *ssh.Client, command string
 	mwr := io.MultiWriter(ex.logs.Out, &stdoutBuf)
 	session.Stdout, session.Stderr = mwr, ex.logs.Err
 
-	done := make(chan error)
+	done := make(chan error, 1) // buffered so the goroutine can finish and exit even if we return on ctx.Done
 	go func() {
 		done <- session.Run(command)
 	}()
@@ -376,17 +376,74 @@ type sftpReq struct {
 	client     *ssh.Client
 }
 
+// newSftpSession opens a per-call sftp client over its own ssh session and returns both. Closing the
+// returned ssh session tears down the channel from outside the sftp mutex, which aborts an in-flight
+// transfer even when a write is stalled with the mutex held; closing the sftp client would instead block
+// on that same mutex. The caller must close both (the sftp client first, then the session).
+// sftpCancelGrace bounds how long a canceled transfer waits for its copy goroutine to unblock after the
+// ssh session is closed. A responsive peer aborts in milliseconds; this grace bounds an app-level wedge
+// (a peer that stops draining the window and ignores the channel close) so it cannot hang the deploy, and
+// past it we return and leave cleanup to the connection teardown. A transport-level wedge (send buffer
+// full, peer host gone, no write deadline) can still block session.Close itself before the grace starts;
+// fully bounding that needs a net.Conn write deadline or ssh keepalive and is left to a follow-up.
+const sftpCancelGrace = 5 * time.Second
+
+func newSftpSession(client *ssh.Client, opts ...sftp.ClientOption) (*sftp.Client, *ssh.Session, error) {
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, nil, err
+	}
+	wr, err := session.StdinPipe()
+	if err != nil {
+		_ = session.Close()
+		return nil, nil, err
+	}
+	rd, err := session.StdoutPipe()
+	if err != nil {
+		_ = session.Close()
+		return nil, nil, err
+	}
+	// drain stderr in the background. for a subsystem session RequestSubsystem never calls session.start,
+	// which is what wires up Session.Stderr, so setting that field does nothing; unread stderr would fill
+	// the channel's extended-data window and stall the transfer. mirror sftp.NewClient, which drains it.
+	perr, err := session.StderrPipe()
+	if err != nil {
+		_ = session.Close()
+		return nil, nil, err
+	}
+	go func() { _, _ = io.Copy(io.Discard, perr) }()
+
+	if err := session.RequestSubsystem("sftp"); err != nil {
+		_ = session.Close()
+		return nil, nil, err
+	}
+	sc, err := sftp.NewClientPipe(rd, wr, opts...)
+	if err != nil {
+		_ = session.Close()
+		return nil, nil, err
+	}
+	return sc, session, nil
+}
+
 func (ex *Remote) sftpUpload(ctx context.Context, req sftpReq) error {
 	log.Printf("[DEBUG] upload %s to %s:%s", req.localFile, req.remoteHost, req.remoteFile)
 	defer func(st time.Time) {
 		log.Printf("[INFO] uploaded %s to %s:%s in %s", req.localFile, req.remoteHost, req.remoteFile, time.Since(st))
 	}(time.Now())
 
-	sftpClient, err := sftp.NewClient(req.client, sftp.UseConcurrentWrites(true))
+	sftpClient, session, err := newSftpSession(req.client, sftp.UseConcurrentWrites(true))
 	if err != nil {
 		return fmt.Errorf("failed to create sftp client: %v", err)
 	}
-	defer sftpClient.Close()
+	// session.Close is ssh-level and always safe; the sftp client/file closes take the shared sftp
+	// mutex, so they are skipped when a wedged transfer leaves it held (see the ctx.Done branch below).
+	skipSftpClose := false
+	defer func() {
+		if !skipSftpClose {
+			_ = sftpClient.Close()
+		}
+		_ = session.Close()
+	}()
 
 	inpFh, err := os.Open(req.localFile)
 	if err != nil {
@@ -422,7 +479,11 @@ func (ex *Remote) sftpUpload(ctx context.Context, req sftpReq) error {
 	if err != nil {
 		return fmt.Errorf("failed to create remote file %q: %v", req.remoteFile, err)
 	}
-	defer remoteFh.Close()
+	defer func() {
+		if !skipSftpClose {
+			_ = remoteFh.Close()
+		}
+	}()
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -432,6 +493,16 @@ func (ex *Remote) sftpUpload(ctx context.Context, req sftpReq) error {
 
 	select {
 	case <-ctx.Done():
+		// close the ssh session to abort the in-flight transfer from outside the sftp mutex, then wait
+		// for the copy goroutine so the deferred Close does not race the io.Copy. bound the wait so an
+		// app-level wedge cannot hang the deploy (see sftpCancelGrace): past the grace we skip the
+		// sftp-mutex closes and return (the goroutine is freed when the ssh client is closed).
+		_ = session.Close()
+		select {
+		case <-errCh:
+		case <-time.After(sftpCancelGrace):
+			skipSftpClose = true
+		}
 		return fmt.Errorf("failed to copy file %q: %v", req.remoteFile, ctx.Err())
 	case err = <-errCh:
 		if err != nil {
@@ -454,17 +525,29 @@ func (ex *Remote) sftpDownload(ctx context.Context, req sftpReq) error {
 	log.Printf("[INFO] download %s from %s:%s", req.localFile, req.remoteHost, req.remoteFile)
 	defer func(st time.Time) { log.Printf("[DEBUG] download done for %q in %s", req.localFile, time.Since(st)) }(time.Now())
 
-	sftpClient, err := sftp.NewClient(req.client)
+	sftpClient, session, err := newSftpSession(req.client)
 	if err != nil {
 		return fmt.Errorf("failed to create sftp client: %v", err)
 	}
-	defer sftpClient.Close()
+	// session.Close is ssh-level and always safe; the sftp client/file closes take the shared sftp
+	// mutex, so they are skipped when a wedged transfer leaves it held (see the ctx.Done branch below).
+	skipSftpClose := false
+	defer func() {
+		if !skipSftpClose {
+			_ = sftpClient.Close()
+		}
+		_ = session.Close()
+	}()
 
 	remoteFh, err := sftpClient.Open(req.remoteFile)
 	if err != nil {
 		return fmt.Errorf("failed to open remote file: %v", err)
 	}
-	defer remoteFh.Close() // nolint
+	defer func() {
+		if !skipSftpClose {
+			_ = remoteFh.Close()
+		}
+	}()
 
 	remoteFi, err := remoteFh.Stat()
 	if err != nil {
@@ -479,11 +562,8 @@ func (ex *Remote) sftpDownload(ctx context.Context, req sftpReq) error {
 		}
 	}
 
-	// check if local file exists and should be skipped
-	fileExists := false
+	// if the local file exists and matches size+modtime, skip the download (force overrides)
 	if localFi, err := os.Stat(req.localFile); err == nil {
-		fileExists = true
-		// if the local file size and mod time are the same as the remote file, don't download. Force flag overrides this.
 		if !req.force && localFi.Size() == remoteFi.Size() && isWithinOneSecond(localFi.ModTime(), remoteFi.ModTime()) {
 			log.Printf("[INFO] local file %s is up-to-date, skipping download", req.localFile)
 			return nil
@@ -492,25 +572,46 @@ func (ex *Remote) sftpDownload(ctx context.Context, req sftpReq) error {
 		return fmt.Errorf("failed to stat local file: %v", err)
 	}
 
-	// open local file for writing (create if doesn't exist, truncate if exists)
-	openFlags := os.O_WRONLY | os.O_CREATE
-	if fileExists {
-		openFlags |= os.O_TRUNC
-	}
-	localFh, err := os.OpenFile(req.localFile, openFlags, 0o600) // nolint:gosec // req.localFile comes from user config
+	// download into a temp file in the same directory and rename over the destination only after the copy
+	// succeeds, so a cancel or error mid-copy leaves any existing destination file intact
+	tmpFh, err := os.CreateTemp(filepath.Dir(req.localFile), "."+filepath.Base(req.localFile)+".spot-*")
 	if err != nil {
-		return fmt.Errorf("failed to open local file: %v", err)
+		return fmt.Errorf("failed to create temp file: %v", err)
 	}
-	defer localFh.Close() // nolint
+	tmpName := tmpFh.Name()
+	renamed := false
+	defer func() {
+		// skipSftpClose means the copy goroutine is wedged and still owns tmpFh, so don't close it here;
+		// unlinking the temp is safe regardless and leaves the destination untouched
+		if !skipSftpClose {
+			_ = tmpFh.Close()
+		}
+		if !renamed {
+			_ = os.Remove(tmpName)
+		}
+	}()
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, e := io.Copy(localFh, remoteFh)
+		_, e := io.Copy(tmpFh, remoteFh)
 		errCh <- e
 	}()
 
 	select {
 	case <-ctx.Done():
+		// close the ssh session to abort the in-flight remote read from outside the sftp mutex, then wait
+		// for the copy goroutine so the deferred Close does not race the io.Copy. bound the wait so an
+		// app-level wedge cannot hang the deploy (see sftpCancelGrace): past the grace we skip the
+		// sftp-mutex closes and return (the goroutine is freed when the ssh client is closed).
+		_ = session.Close()
+		select {
+		case <-errCh:
+		case <-time.After(sftpCancelGrace):
+			skipSftpClose = true
+			// the copy goroutine is wedged and still owns tmpFh; close the fd once it finally unblocks
+			// (when the ssh client is closed) so it is not leaked until process exit
+			go func() { <-errCh; _ = tmpFh.Close() }()
+		}
 		return ctx.Err()
 	case err = <-errCh:
 		if err != nil {
@@ -518,14 +619,24 @@ func (ex *Remote) sftpDownload(ctx context.Context, req sftpReq) error {
 		}
 	}
 
-	if err = localFh.Sync(); err != nil {
+	if err = tmpFh.Sync(); err != nil {
 		return fmt.Errorf("failed to sync local file: %v", err)
 	}
+	if err = tmpFh.Close(); err != nil {
+		return fmt.Errorf("failed to close local file: %v", err)
+	}
 
-	// set local file's modtime to match remote file's modtime for proper comparison in future downloads
-	if err = os.Chtimes(req.localFile, remoteFi.ModTime(), remoteFi.ModTime()); err != nil {
+	// set the temp file's modtime to match the remote file, so the up-to-date check matches after the rename
+	if err = os.Chtimes(tmpName, remoteFi.ModTime(), remoteFi.ModTime()); err != nil {
 		return fmt.Errorf("failed to set modification time of local file %q: %v", req.localFile, err)
 	}
+
+	// same-dir rename replaces the destination atomically on unix (a best-effort replace elsewhere); either
+	// way the existing file is only touched here, after a fully successful download
+	if err = os.Rename(tmpName, req.localFile); err != nil {
+		return fmt.Errorf("failed to move downloaded file into place: %v", err)
+	}
+	renamed = true
 
 	return nil
 }

--- a/pkg/executor/remote_test.go
+++ b/pkg/executor/remote_test.go
@@ -295,6 +295,64 @@ func TestExecuter_UploadCanceledWithoutMkdir(t *testing.T) {
 	require.EqualError(t, err, "failed to copy file \"/tmp/data1.txt\": context canceled")
 }
 
+func TestExecuter_TransferCancellation(t *testing.T) {
+	ctx := context.Background()
+	hostAndPort, teardown := startTestContainer(t)
+	defer teardown()
+
+	c, err := NewConnector("testdata/test_ssh_key", time.Second*10, MakeLogs(true, false, nil))
+	require.NoError(t, err)
+	sess, err := c.Connect(ctx, hostAndPort, "h1", "test")
+	require.NoError(t, err)
+	defer sess.Close()
+
+	t.Run("upload aborts mid-transfer, never hangs", func(t *testing.T) {
+		// large enough that the transfer is still in flight when we cancel shortly after starting
+		big := filepath.Join(t.TempDir(), "big.bin")
+		require.NoError(t, os.WriteFile(big, make([]byte, 16*1024*1024), 0o644))
+
+		upCtx, cancel := context.WithCancel(ctx)
+		time.AfterFunc(15*time.Millisecond, cancel)
+
+		done := make(chan error, 1)
+		go func() { done <- sess.Upload(upCtx, big, "/tmp/big.bin", &UpDownOpts{Mkdir: true}) }()
+
+		select {
+		case err := <-done:
+			t.Logf("upload returned after cancel: %v", err)
+		case <-time.After(30 * time.Second):
+			t.Fatal("upload did not return after cancellation - transfer was not aborted")
+		}
+	})
+
+	t.Run("canceled download preserves the existing file", func(t *testing.T) {
+		// a remote file large enough that the copy is still in flight when the (already canceled) select runs
+		_, e := sess.Run(ctx, "head -c 16777216 /dev/zero > /tmp/big.remote", &RunOpts{Verbose: true})
+		require.NoError(t, e)
+
+		// an existing local file with known content that a canceled overwrite must not destroy
+		dst := filepath.Join(t.TempDir(), "dest.bin")
+		orig := []byte("original important content that must survive a canceled download")
+		require.NoError(t, os.WriteFile(dst, orig, 0o644))
+
+		dlCtx, cancel := context.WithCancel(ctx)
+		cancel() // canceled before the copy can complete
+
+		err := sess.Download(dlCtx, "/tmp/big.remote", dst, &UpDownOpts{Force: true})
+		require.Error(t, err, "canceled download should return an error")
+
+		got, rerr := os.ReadFile(dst)
+		require.NoError(t, rerr)
+		assert.Equal(t, orig, got, "canceled download must leave the existing file intact, not truncated")
+
+		entries, rerr := os.ReadDir(filepath.Dir(dst))
+		require.NoError(t, rerr)
+		for _, en := range entries {
+			assert.NotContains(t, en.Name(), ".spot-", "no temp download file should be left behind")
+		}
+	})
+}
+
 func TestUpload_UploadOverwriteWithAndWithoutForce(t *testing.T) {
 	ctx := context.Background()
 	hostAndPort, teardown := startTestContainer(t)

--- a/pkg/runner/commands.go
+++ b/pkg/runner/commands.go
@@ -376,7 +376,7 @@ func (ec *execCmd) Sync(ctx context.Context) (resp execCmdResp, err error) {
 	src := tmpl.apply(ec.cmd.Sync.Source)
 	dst := tmpl.apply(ec.cmd.Sync.Dest)
 	resp.details = fmt.Sprintf(" {sync: %s -> %s}", src, dst)
-	opts := &executor.SyncOpts{Delete: ec.cmd.Sync.Delete, Exclude: ec.cmd.Sync.Exclude, Force: ec.cmd.Sync.Force}
+	opts := &executor.SyncOpts{Delete: ec.cmd.Sync.Delete, Exclude: ec.cmd.Sync.Exclude}
 	if _, err := ec.exec.Sync(ctx, src, dst, opts); err != nil {
 		return resp, ec.errorFmt("can't sync files on %s: %w", ec.hostAddr, err)
 	}
@@ -392,7 +392,7 @@ func (ec *execCmd) Msync(ctx context.Context) (resp execCmdResp, err error) {
 		dst := tmpl.apply(c.Dest)
 		msgs = append(msgs, fmt.Sprintf("%s -> %s", src, dst))
 		ecSingle := ec
-		ecSingle.cmd.Sync = config.SyncInternal{Source: src, Dest: dst, Exclude: c.Exclude, Delete: c.Delete, Force: c.Force}
+		ecSingle.cmd.Sync = config.SyncInternal{Source: src, Dest: dst, Exclude: c.Exclude, Delete: c.Delete}
 		if _, err := ecSingle.Sync(ctx); err != nil {
 			return resp, ec.errorFmt("can't sync %s to %s %s: %w", src, ec.hostAddr, dst, err)
 		}

--- a/schemas/playbook.json
+++ b/schemas/playbook.json
@@ -461,11 +461,6 @@
             "type": "string"
           },
           "description": "Patterns to exclude from sync"
-        },
-        "force": {
-          "type": "boolean",
-          "default": false,
-          "description": "Force sync even if files are identical"
         }
       }
     },


### PR DESCRIPTION
Executor correctness and resource-safety fixes found during review.

- **sshRun**: the `done` channel was unbuffered, so on a ctx-cancel return the command goroutine blocked forever on the send — a goroutine leak per cancelled command. It is now buffered.
- **sftpUpload / sftpDownload**: on ctx-cancel the function returned while the `io.Copy` goroutine was still writing, so the deferred `Close` raced the copy. It now closes the per-call sftp client to abort the in-flight transfer, then drains the copy goroutine before returning. Closing the client (not the file) avoids blocking behind the sftp write mutex, so cancellation stays prompt and race-free.
- **Local.Upload**: with a multi-file glob and `mkdir`, it created only the parent of `dst` even though `dst` is treated as a directory for multiple matches, so the copy then failed. It now creates `dst` itself in that case, and honors context cancellation between files.
- **Local.Download**: passes the caller context through instead of `context.Background()`.
- **Connector.String**: guarded the `privateKey[:8]` slice so it no longer panics on short or empty (agent-only) keys.
- Removed dead options never read by any executor: `Checksum` from `UpDownOpts` and `SyncOpts`, and `Force` from `SyncOpts`. This also drops the config `sync.force` field (an undocumented no-op) and its schema entry — under strict YAML parsing a playbook that set `sync: {force: true}` would now fail to parse, which is intended cleanup.

New tests cover the multi-glob mkdir, local upload cancellation, and the Connector.String guard (negative-checked); the sftp cancel paths pass under `-race` with no hang.

Note: codex's first xhigh review of this PR caught a real issue in the initial sftp-cancel approach (closing the file handle could block behind the sftp write mutex), which is fixed here by closing the client instead. The follow-up confirmation review could not complete in my environment (the review process was repeatedly killed mid-run), so the client-close fix was self-reviewed and validated with the -race cancel tests.