### PR TITLE
Fix local executor failing on output lines over 64KiB

### DIFF
--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -59,11 +58,22 @@ func (l *Local) Run(ctx context.Context, cmd string, _ *RunOpts) (out []string, 
 		return nil, err
 	}
 
-	scanner := bufio.NewScanner(&stdoutBuf)
-	for scanner.Scan() {
-		out = append(out, scanner.Text())
+	return splitOutputLines(stdoutBuf.String()), nil
+}
+
+// splitOutputLines splits captured command output into lines the same way bufio.ScanLines does, i.e. dropping
+// a trailing \r and the empty element after the final newline, but without the scanner's token size limit.
+// The output is already fully buffered, so a single line of any length is returned as is.
+func splitOutputLines(s string) []string {
+	if s == "" {
+		return nil
 	}
-	return out, scanner.Err()
+	lines := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
+	res := make([]string, 0, len(lines))
+	for _, line := range lines {
+		res = append(res, strings.TrimSuffix(line, "\r"))
+	}
+	return res
 }
 
 // Upload just copy file from one place to another

--- a/pkg/executor/local_test.go
+++ b/pkg/executor/local_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -71,6 +72,17 @@ func TestRun(t *testing.T) {
 		assert.Contains(t, out, "/tmp/st/data2.txt")
 	})
 
+	t.Run("line over the scanner buffer limit", func(t *testing.T) {
+		quiet := NewLocal(MakeLogs(false, false, nil)) // non-verbose logs go to the std logger, muted below
+		defer log.SetOutput(os.Stderr)
+		log.SetOutput(io.Discard)
+
+		out, e := quiet.Run(ctx, "head -c 100000 /dev/zero | tr '\\0' 'x'", nil)
+		require.NoError(t, e)
+		require.Len(t, out, 1)
+		assert.Len(t, out[0], 100000)
+	})
+
 	t.Run("with secrets", func(t *testing.T) {
 		stdout := captureStdOut(t, func() {
 			l := NewLocal(MakeLogs(true, false, []string{"data2"}))
@@ -84,6 +96,28 @@ func TestRun(t *testing.T) {
 		assert.NotContains(t, stdout, "data2", "captured stdout should not contain secrets")
 		assert.Contains(t, stdout, "****", "captured stdout should contain masked secrets")
 	})
+}
+
+func TestSplitOutputLines(t *testing.T) {
+	tbl := []struct {
+		name string
+		in   string
+		res  []string
+	}{
+		{"empty", "", nil},
+		{"single line, no trailing newline", "hello", []string{"hello"}},
+		{"single line with trailing newline", "hello\n", []string{"hello"}},
+		{"multiple lines", "line1\nline2\nline3\n", []string{"line1", "line2", "line3"}},
+		{"blank line in the middle", "line1\n\nline2\n", []string{"line1", "", "line2"}},
+		{"single newline", "\n", []string{""}},
+		{"trailing blank line", "line1\n\n", []string{"line1", ""}},
+		{"crlf line endings", "line1\r\nline2\r\n", []string{"line1", "line2"}},
+	}
+	for _, tt := range tbl {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.res, splitOutputLines(tt.in))
+		})
+	}
 }
 
 func TestUploadAndDownload(t *testing.T) {


### PR DESCRIPTION
Previously, `Local.Run` split the captured output with a default `bufio.Scanner`, so a command printing a single line longer than 64KiB failed with `bufio.Scanner: token too long` even though the command itself had succeeded. The remote executor has no such limit, since `Remote.sshRun` splits the buffered output with `strings.SplitSeq`, so the same playbook behaved differently depending on whether it ran locally or over ssh.

On master:

```sh
$ cat longline.sh
#!/bin/sh
awk 'BEGIN{printf "%100000s\n", ""}'

$ spot --local -p longline.yml -t localhost
[0] failed command "emit one long line" on host localhost:0 (localhost): can't run script on localhost:0: bufio.Scanner: token too long
```

After this change the same playbook completes. The output is fully buffered in memory by the time it is split, so the scanner's bounded reads bought nothing, and splitting the buffer in place returns a line of any length as it is. The splitting keeps `bufio.ScanLines` semantics, dropping a trailing `\r` and the empty element after the final newline, so nothing changes for existing playbooks; `TestSplitOutputLines` pins that down case by case.
