### PR TITLE
executor: filter command output lines instead of buffering all of them

### DIFF
--- a/pkg/executor/dry.go
+++ b/pkg/executor/dry.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"log"
@@ -21,12 +20,12 @@ func NewDry(logs Logs) *Dry {
 }
 
 // Run shows the command content, doesn't execute it
-func (ex *Dry) Run(_ context.Context, cmd string, _ *RunOpts) (out []string, err error) {
+func (ex *Dry) Run(_ context.Context, cmd string, opts *RunOpts) (out []string, err error) {
 	log.Printf("[DEBUG] run %s", cmd)
-	var stdoutBuf bytes.Buffer
-	mwr := io.MultiWriter(ex.logs.Out, &stdoutBuf)
+	capture := newLineCapture(opts)
+	mwr := io.MultiWriter(ex.logs.Out, capture)
 	mwr.Write([]byte(cmd)) // nolint
-	return splitOutputLines(stdoutBuf.String()), nil
+	return capture.result(), nil
 }
 
 // Upload doesn't actually upload, just prints the command

--- a/pkg/executor/dry_test.go
+++ b/pkg/executor/dry_test.go
@@ -18,14 +18,14 @@ func TestDry_Run(t *testing.T) {
 	dry := NewDry(MakeLogs(true, false, nil))
 
 	t.Run("single line", func(t *testing.T) {
-		res, err := dry.Run(ctx, "ls -la /srv", &RunOpts{Verbose: true})
+		res, err := dry.Run(ctx, "ls -la /srv", nil)
 		require.NoError(t, err)
 		require.Len(t, res, 1)
 		require.Equal(t, "ls -la /srv", res[0])
 	})
 
 	t.Run("multi line with blank line", func(t *testing.T) {
-		res, err := dry.Run(ctx, "ls -la /srv\n\ndf -h\n", &RunOpts{Verbose: true})
+		res, err := dry.Run(ctx, "ls -la /srv\n\ndf -h\n", nil)
 		require.NoError(t, err)
 		require.Equal(t, []string{"ls -la /srv", "", "df -h"}, res)
 	})
@@ -143,7 +143,7 @@ func TestDry_RunLineOverScannerLimit(t *testing.T) {
 	logs.Out = logs.Out.WithWriter(&buf)
 
 	cmd := strings.Repeat("x", 100000)
-	res, err := NewDry(logs).Run(context.Background(), cmd, &RunOpts{Verbose: true})
+	res, err := NewDry(logs).Run(context.Background(), cmd, nil)
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	assert.Equal(t, cmd, res[0])

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -92,10 +92,22 @@ func (lc *lineCapture) Write(p []byte) (n int, err error) {
 		} else {
 			lc.partial = append(lc.partial, p[:i]...)
 			lc.take(lc.partial)
-			lc.partial = lc.partial[:0]
+			lc.reset()
 		}
 		p = p[i+1:]
 	}
+}
+
+// reset readies the staging buffer for the next line. A buffer that stayed small is kept, sparing an
+// allocation per line, but a large one is released: holding it would pin the longest line for the rest
+// of the command, which is the retention this type exists to avoid.
+func (lc *lineCapture) reset() {
+	const maxStageReuse = 64 << 10
+	if cap(lc.partial) > maxStageReuse {
+		lc.partial = nil
+		return
+	}
+	lc.partial = lc.partial[:0]
 }
 
 // take converts one line and keeps it if the predicate accepts. The string conversion copies, so

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -3,6 +3,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"path"
 	"strings"
@@ -21,8 +22,12 @@ type Interface interface {
 }
 
 // RunOpts is a struct for run options.
+// Note it is not comparable, since KeepLine is a func.
 type RunOpts struct {
-	Verbose bool // print more info to primary stdout
+	// KeepLine decides which stdout lines Run returns; a nil predicate keeps every line.
+	// Every line still reaches the log in full, so this bounds only what the caller holds:
+	// a command printing a large log costs nothing extra when its output is not read.
+	KeepLine func(line string) bool
 }
 
 // UpDownOpts is a struct for upload and download options.
@@ -62,6 +67,61 @@ func splitOutputLines(s string) []string {
 		res = append(res, strings.TrimSuffix(line, "\r"))
 	}
 	return res
+}
+
+// lineCapture splits everything written to it into lines exactly as splitOutputLines does, keeping
+// only the ones keep accepts. Executors pass it alongside the log writer, so retention scales with
+// what the caller reads rather than with what the command printed. A line of any length is handled,
+// there is no scanner token limit, and an unterminated final line is returned like a terminated one.
+type lineCapture struct {
+	keep    func(line string) bool
+	partial []byte
+	lines   []string
+}
+
+func (lc *lineCapture) Write(p []byte) (n int, err error) {
+	n = len(p)
+	for {
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			lc.partial = append(lc.partial, p...)
+			return n, nil
+		}
+		if len(lc.partial) == 0 {
+			lc.take(p[:i]) // whole line arrived in this write, no need to stage it
+		} else {
+			lc.partial = append(lc.partial, p[:i]...)
+			lc.take(lc.partial)
+			lc.partial = lc.partial[:0]
+		}
+		p = p[i+1:]
+	}
+}
+
+// take converts one line and keeps it if the predicate accepts. The string conversion copies, so
+// the retained line never pins the writer's buffer, and a rejected line is garbage at once.
+func (lc *lineCapture) take(b []byte) {
+	line := string(bytes.TrimSuffix(b, []byte("\r")))
+	if lc.keep == nil || lc.keep(line) {
+		lc.lines = append(lc.lines, line)
+	}
+}
+
+// result flushes an unterminated final line and returns the kept lines, nil when nothing was kept.
+func (lc *lineCapture) result() []string {
+	if len(lc.partial) > 0 {
+		lc.take(lc.partial)
+		lc.partial = nil
+	}
+	return lc.lines
+}
+
+// newLineCapture builds a capture honoring opts, which may be nil.
+func newLineCapture(opts *RunOpts) *lineCapture {
+	if opts == nil {
+		return &lineCapture{}
+	}
+	return &lineCapture{keep: opts.KeepLine}
 }
 
 // isExcluded reports whether fpath matches any of the exclude patterns. A pattern ending in "/*"

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -224,3 +224,15 @@ func writeInChunks(t *testing.T, w io.Writer, s string, size int) {
 		require.NoError(t, err)
 	}
 }
+
+func TestLineCaptureReleasesLargeStagingBuffer(t *testing.T) {
+	// a long line arriving in pieces has to be staged, but once it is consumed the buffer must go:
+	// keeping it would pin the longest line for as long as the command runs, which is the retention
+	// this type exists to remove
+	lc := &lineCapture{keep: func(string) bool { return false }}
+	writeInChunks(t, lc, strings.Repeat("x", 4<<20)+"\n", 4096)
+	assert.LessOrEqual(t, cap(lc.partial), 64<<10, "the staging buffer is released once the line is consumed")
+
+	writeInChunks(t, lc, "short\n", 2) // still usable for the output that follows
+	assert.Nil(t, lc.result())
+}

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -2,8 +2,10 @@ package executor
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,5 +145,82 @@ func TestSplitOutputLines(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.res, splitOutputLines(tt.in))
 		})
+	}
+}
+
+func TestLineCapture(t *testing.T) {
+	tbl := []struct {
+		name string
+		in   string
+		res  []string
+	}{
+		{"empty", "", nil},
+		{"single line, no trailing newline", "hello", []string{"hello"}},
+		{"single line with trailing newline", "hello\n", []string{"hello"}},
+		{"multiple lines", "line1\nline2\nline3\n", []string{"line1", "line2", "line3"}},
+		{"blank line in the middle", "line1\n\nline2\n", []string{"line1", "", "line2"}},
+		{"single newline", "\n", []string{""}},
+		{"trailing blank line", "line1\n\n", []string{"line1", ""}},
+		{"crlf line endings", "line1\r\nline2\r\n", []string{"line1", "line2"}},
+	}
+
+	// a nil predicate reproduces splitOutputLines whatever the write boundaries are, including a
+	// chunk size that splits a line, a crlf pair or a run of newlines
+	for _, tt := range tbl {
+		for _, chunk := range []int{0, 1, 2, 3, 7} {
+			t.Run(fmt.Sprintf("%s/chunk %d", tt.name, chunk), func(t *testing.T) {
+				lc := &lineCapture{}
+				writeInChunks(t, lc, tt.in, chunk)
+				assert.Equal(t, tt.res, lc.result())
+				assert.Equal(t, splitOutputLines(tt.in), lc.result(), "result is idempotent and matches the batch split")
+			})
+		}
+	}
+}
+
+func TestLineCaptureKeepLine(t *testing.T) {
+	t.Run("keeps only accepted lines", func(t *testing.T) {
+		lc := &lineCapture{keep: func(line string) bool { return strings.HasPrefix(line, "setvar ") }}
+		writeInChunks(t, lc, "noise\nsetvar a=1\nmore noise\nsetvar b=2\n", 3)
+		assert.Equal(t, []string{"setvar a=1", "setvar b=2"}, lc.result())
+	})
+
+	t.Run("rejecting everything retains nothing", func(t *testing.T) {
+		lc := &lineCapture{keep: func(string) bool { return false }}
+		writeInChunks(t, lc, "one\ntwo\nthree", 0)
+		assert.Nil(t, lc.result())
+	})
+
+	t.Run("predicate sees an unterminated final line", func(t *testing.T) {
+		var seen []string
+		lc := &lineCapture{keep: func(line string) bool { seen = append(seen, line); return true }}
+		writeInChunks(t, lc, "first\nlast-no-newline", 4)
+		assert.Equal(t, []string{"first"}, seen, "the final line is only offered once result is called")
+		assert.Equal(t, []string{"first", "last-no-newline"}, lc.result())
+	})
+
+	t.Run("line longer than a scanner token limit survives", func(t *testing.T) {
+		long := strings.Repeat("x", 1<<20)
+		lc := &lineCapture{}
+		writeInChunks(t, lc, long+"\nshort\n", 4096)
+		require.Len(t, lc.result(), 2)
+		assert.Equal(t, long, lc.result()[0])
+		assert.Equal(t, "short", lc.result()[1])
+	})
+}
+
+// writeInChunks feeds s to w in fixed-size pieces, or in one write when size is 0, so a test can
+// pin behavior across the write boundaries a real command produces.
+func writeInChunks(t *testing.T, w io.Writer, s string, size int) {
+	t.Helper()
+	if size <= 0 {
+		_, err := w.Write([]byte(s))
+		require.NoError(t, err)
+		return
+	}
+	for i := 0; i < len(s); i += size {
+		end := min(i+size, len(s))
+		_, err := w.Write([]byte(s[i:end]))
+		require.NoError(t, err)
 	}
 }

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -27,7 +26,7 @@ func NewLocal(logs Logs) *Local {
 }
 
 // Run executes command on local hostAddr, inside the shell
-func (l *Local) Run(ctx context.Context, cmd string, _ *RunOpts) (out []string, err error) {
+func (l *Local) Run(ctx context.Context, cmd string, opts *RunOpts) (out []string, err error) {
 	shell := func() string {
 		if strings.HasPrefix(cmd, "sh -c") {
 			return "sh" // command has sh -c prefix, so use sh
@@ -51,15 +50,15 @@ func (l *Local) Run(ctx context.Context, cmd string, _ *RunOpts) (out []string, 
 	errLog := l.logs.Err.WithHost("localhost", "")
 	outLog.Write([]byte(cmd)) // nolint
 
-	var stdoutBuf bytes.Buffer
-	mwr := io.MultiWriter(outLog, &stdoutBuf)
+	capture := newLineCapture(opts)
+	mwr := io.MultiWriter(outLog, capture)
 	command.Stdout, command.Stderr = mwr, errLog
 	err = command.Run()
 	if err != nil {
 		return nil, err
 	}
 
-	return splitOutputLines(stdoutBuf.String()), nil
+	return capture.result(), nil
 }
 
 // Upload just copy file from one place to another

--- a/pkg/executor/local_test.go
+++ b/pkg/executor/local_test.go
@@ -21,19 +21,19 @@ func TestRun(t *testing.T) {
 	l := NewLocal(MakeLogs(true, false, nil))
 
 	t.Run("single line out, success", func(t *testing.T) {
-		out, e := l.Run(ctx, "echo 'hello world'", &RunOpts{Verbose: true})
+		out, e := l.Run(ctx, "echo 'hello world'", nil)
 		require.NoError(t, e)
 		assert.Equal(t, []string{"hello world"}, out)
 	})
 
 	t.Run("single line with sh -c, success", func(t *testing.T) {
-		out, e := l.Run(ctx, "sh -c echo hello world", &RunOpts{Verbose: true})
+		out, e := l.Run(ctx, "sh -c echo hello world", nil)
 		require.NoError(t, e)
 		assert.Equal(t, []string{"hello world"}, out)
 	})
 
 	t.Run("single line with sh -c with single quotes, success", func(t *testing.T) {
-		out, e := l.Run(ctx, "sh -c 'echo hello world'", &RunOpts{Verbose: true})
+		out, e := l.Run(ctx, "sh -c 'echo hello world'", nil)
 		require.NoError(t, e)
 		assert.Equal(t, []string{"hello world"}, out)
 	})
@@ -45,11 +45,11 @@ func TestRun(t *testing.T) {
 
 	t.Run("multi line out success", func(t *testing.T) {
 		// prepare the test environment
-		_, err := l.Run(ctx, "mkdir -p /tmp/st", &RunOpts{Verbose: true})
+		_, err := l.Run(ctx, "mkdir -p /tmp/st", nil)
 		require.NoError(t, err)
-		_, err = l.Run(ctx, "cp testdata/data1.txt /tmp/st/data1.txt", &RunOpts{Verbose: true})
+		_, err = l.Run(ctx, "cp testdata/data1.txt /tmp/st/data1.txt", nil)
 		require.NoError(t, err)
-		_, err = l.Run(ctx, "cp testdata/data2.txt /tmp/st/data2.txt", &RunOpts{Verbose: true})
+		_, err = l.Run(ctx, "cp testdata/data2.txt /tmp/st/data2.txt", nil)
 		require.NoError(t, err)
 
 		out, err := l.Run(ctx, "ls -1 /tmp/st", nil)
@@ -65,7 +65,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("find out", func(t *testing.T) {
-		out, e := l.Run(ctx, "find /tmp/st -type f", &RunOpts{Verbose: true})
+		out, e := l.Run(ctx, "find /tmp/st -type f", nil)
 		require.NoError(t, e)
 		slices.Sort(out)
 		assert.Contains(t, out, "/tmp/st/data1.txt")
@@ -86,7 +86,7 @@ func TestRun(t *testing.T) {
 	t.Run("with secrets", func(t *testing.T) {
 		stdout := captureStdOut(t, func() {
 			l := NewLocal(MakeLogs(true, false, []string{"data2"}))
-			out, e := l.Run(ctx, "find /tmp/st -type f", &RunOpts{Verbose: true})
+			out, e := l.Run(ctx, "find /tmp/st -type f", nil)
 			require.NoError(t, e)
 			slices.Sort(out)
 			assert.Equal(t, []string{"/tmp/st/data1.txt", "/tmp/st/data2.txt"}, out)

--- a/pkg/executor/logger.go
+++ b/pkg/executor/logger.go
@@ -52,7 +52,7 @@ type colorizedWriter struct {
 	prefix     string
 	hostAddr   string
 	hostName   string
-	secrets    []string
+	masker     *secretsMasker
 	monochrome bool
 }
 
@@ -64,18 +64,18 @@ func (s *colorizedWriter) WithHost(hostAddr, hostName string) LogWriter {
 		hostName = ""
 	}
 	return &colorizedWriter{wr: s.wr, hostAddr: hostAddr, hostName: hostName,
-		prefix: s.prefix, secrets: s.secrets, monochrome: s.monochrome}
+		prefix: s.prefix, masker: s.masker, monochrome: s.monochrome}
 }
 
 func (s *colorizedWriter) WithWriter(wr io.Writer) LogWriter {
 	return &colorizedWriter{wr: wr, hostAddr: s.hostAddr, hostName: s.hostName,
-		prefix: s.prefix, secrets: s.secrets, monochrome: s.monochrome}
+		prefix: s.prefix, masker: s.masker, monochrome: s.monochrome}
 }
 
 // Printf writes the given text to io.Writer with the colorized hostAddr prefix.
 func (s *colorizedWriter) Printf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
-	msg = maskSecrets(msg, s.secrets)
+	msg = s.masker.mask(msg)
 	_, _ = fmt.Fprint(s, msg)
 }
 
@@ -88,7 +88,7 @@ func (s *colorizedWriter) Write(p []byte) (n int, err error) {
 			hostID = s.hostName + " " + s.hostAddr
 		}
 		formattedOutput := fmt.Sprintf("[%s] %s %s", hostID, s.prefix, line)
-		formattedOutput = maskSecrets(formattedOutput, s.secrets)
+		formattedOutput = s.masker.mask(formattedOutput)
 
 		if s.prefix == "" {
 			formattedOutput = fmt.Sprintf("[%s] %s", hostID, line)
@@ -125,17 +125,28 @@ func (s *colorizedWriter) hostColorizer(host string) func(format string, a ...an
 // infoLog is always colorized and used to log the main info, like the command that is being executed.
 func MakeLogs(verbose, bw bool, secrets []string) Logs {
 	var infoLog, outLog, errLog LogWriter
-	infoLog = &colorizedWriter{wr: os.Stdout, prefix: "", secrets: secrets, monochrome: bw}
-	outLog = &stdOutLogWriter{prefix: " >", level: "DEBUG", secrets: secrets}
-	errLog = &stdOutLogWriter{prefix: " !", level: "WARN", secrets: secrets}
+	masker := newSecretsMasker(secrets) // compiled once here and shared by every writer below
+	infoLog = &colorizedWriter{wr: os.Stdout, prefix: "", masker: masker, monochrome: bw}
+	outLog = &stdOutLogWriter{prefix: " >", level: "DEBUG", masker: masker}
+	errLog = &stdOutLogWriter{prefix: " !", level: "WARN", masker: masker}
 	if verbose {
-		outLog = &colorizedWriter{wr: os.Stdout, prefix: " >", secrets: secrets, monochrome: bw}
-		errLog = &colorizedWriter{wr: os.Stdout, prefix: " !", secrets: secrets, monochrome: bw}
+		outLog = &colorizedWriter{wr: os.Stdout, prefix: " >", masker: masker, monochrome: bw}
+		errLog = &colorizedWriter{wr: os.Stdout, prefix: " !", masker: masker, monochrome: bw}
 	}
 	return Logs{Info: infoLog, Out: outLog, Err: errLog, verbose: verbose, secrets: secrets, monochrome: bw}
 }
 
-func maskSecrets(s string, secrets []string) string {
+// secretsMasker replaces known secret values in log output. Patterns are compiled once per masker
+// rather than per call: masking runs for every line of every command, and recompiling there
+// dominated the cost of the output path.
+type secretsMasker struct {
+	patterns []*regexp.Regexp
+}
+
+// newSecretsMasker compiles one pattern per usable secret, in the order given, since masking
+// applies them in sequence. A nil or empty list yields a masker that returns its input.
+func newSecretsMasker(secrets []string) *secretsMasker {
+	m := &secretsMasker{}
 	for _, secret := range secrets {
 		if secret == " " || secret == "" {
 			continue
@@ -144,12 +155,21 @@ func maskSecrets(s string, secrets []string) string {
 		// if the secret contains alphanumeric characters only, use word boundaries for better precision
 		pattern := regexp.QuoteMeta(secret)
 		if isAlphanumeric(secret) {
-			re := regexp.MustCompile(`\b` + pattern + `\b`)
-			s = re.ReplaceAllString(s, "****")
-		} else {
-			re := regexp.MustCompile(pattern)
-			s = re.ReplaceAllString(s, "****")
+			pattern = `\b` + pattern + `\b`
 		}
+		m.patterns = append(m.patterns, regexp.MustCompile(pattern))
+	}
+	return m
+}
+
+// mask replaces every configured secret in s. A nil masker leaves s untouched, so a writer built
+// without one still works.
+func (m *secretsMasker) mask(s string) string {
+	if m == nil {
+		return s
+	}
+	for _, re := range m.patterns {
+		s = re.ReplaceAllString(s, "****")
 	}
 	return s
 }
@@ -172,9 +192,9 @@ func isAlphanumeric(s string) bool {
 
 // stdOutLogWriter is a writer that writes to log with a prefix and a log level.
 type stdOutLogWriter struct {
-	prefix  string
-	level   string
-	secrets []string
+	prefix string
+	level  string
+	masker *secretsMasker
 }
 
 func (w *stdOutLogWriter) Write(p []byte) (n int, err error) {
@@ -182,7 +202,7 @@ func (w *stdOutLogWriter) Write(p []byte) (n int, err error) {
 		if line == "" {
 			continue
 		}
-		line = maskSecrets(line, w.secrets)
+		line = w.masker.mask(line)
 		log.Printf("[%s] %s %s", w.level, w.prefix, line)
 	}
 	return len(p), nil

--- a/pkg/executor/logger_test.go
+++ b/pkg/executor/logger_test.go
@@ -99,9 +99,9 @@ func TestStdOutLogWriter(t *testing.T) {
 			log.SetFlags(0)
 
 			writer := &stdOutLogWriter{
-				prefix:  tc.prefix,
-				level:   tc.level,
-				secrets: tc.secrets,
+				prefix: tc.prefix,
+				level:  tc.level,
+				masker: newSecretsMasker(tc.secrets),
 			}
 
 			n, err := writer.Write([]byte(tc.input))
@@ -222,7 +222,7 @@ func TestColorizedWriter(t *testing.T) {
 			var writer LogWriter
 			buffer := bytes.NewBuffer([]byte{})
 			writer = &colorizedWriter{wr: buffer, prefix: tc.prefix,
-				hostAddr: tc.hostAddr, hostName: tc.hostName, secrets: tc.secrets}
+				hostAddr: tc.hostAddr, hostName: tc.hostName, masker: newSecretsMasker(tc.secrets)}
 			if tc.withHostName != "" && tc.withHostAddr != "" {
 				writer = writer.WithHost(tc.withHostAddr, tc.withHostName)
 			}
@@ -326,7 +326,7 @@ func TestMaskSecrets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			output := maskSecrets(tt.input, tt.secrets)
+			output := newSecretsMasker(tt.secrets).mask(tt.input)
 			assert.Equal(t, tt.expected, output)
 		})
 	}
@@ -354,7 +354,7 @@ func TestColorizedWriter_PrintfWithSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			var buf bytes.Buffer
-			writer := &colorizedWriter{wr: &buf, secrets: tt.secrets, hostAddr: "localhost", hostName: "my-host"}
+			writer := &colorizedWriter{wr: &buf, masker: newSecretsMasker(tt.secrets), hostAddr: "localhost", hostName: "my-host"}
 			writer.Printf("%s", tt.input) //nolint
 			assert.Equal(t, tt.expected, buf.String())
 		})

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -34,13 +33,13 @@ func (ex *Remote) Close() error {
 }
 
 // Run command on remote server.
-func (ex *Remote) Run(ctx context.Context, cmd string, _ *RunOpts) (out []string, err error) {
+func (ex *Remote) Run(ctx context.Context, cmd string, opts *RunOpts) (out []string, err error) {
 	if ex.client == nil {
 		return nil, fmt.Errorf("client is not connected")
 	}
 	log.Printf("[DEBUG] run %s", cmd)
 
-	return ex.sshRun(ctx, ex.client, cmd)
+	return ex.sshRun(ctx, ex.client, cmd, opts)
 }
 
 // Upload file to remote server with scp
@@ -325,7 +324,7 @@ func (ex *Remote) Delete(ctx context.Context, remoteFile string, opts *DeleteOpt
 }
 
 // sshRun executes command on remote server. context close sends interrupt signal to the remote process.
-func (ex *Remote) sshRun(ctx context.Context, client *ssh.Client, command string) (out []string, err error) {
+func (ex *Remote) sshRun(ctx context.Context, client *ssh.Client, command string, opts *RunOpts) (out []string, err error) {
 	log.Printf("[DEBUG] run ssh command %q on %s", command, client.RemoteAddr().String())
 	session, err := client.NewSession()
 	if err != nil {
@@ -335,8 +334,8 @@ func (ex *Remote) sshRun(ctx context.Context, client *ssh.Client, command string
 
 	ex.logs.Out.Write([]byte(command)) // nolint
 
-	var stdoutBuf bytes.Buffer
-	mwr := io.MultiWriter(ex.logs.Out, &stdoutBuf)
+	capture := newLineCapture(opts)
+	mwr := io.MultiWriter(ex.logs.Out, capture)
 	session.Stdout, session.Stderr = mwr, ex.logs.Err
 
 	done := make(chan error, 1) // buffered so the goroutine can finish and exit even if we return on ctx.Done
@@ -356,7 +355,7 @@ func (ex *Remote) sshRun(ctx context.Context, client *ssh.Client, command string
 		return nil, fmt.Errorf("canceled: %w", ctx.Err())
 	}
 
-	return splitOutputLines(stdoutBuf.String()), nil
+	return capture.result(), nil
 }
 
 type sftpReq struct {

--- a/pkg/executor/remote_test.go
+++ b/pkg/executor/remote_test.go
@@ -183,7 +183,7 @@ func TestExecuter_UploadGlobExcludeDirectory(t *testing.T) {
 	err = sess.Upload(ctx, filepath.Join(srcDir, "*"), "/tmp/globex", &UpDownOpts{Mkdir: true, Exclude: []string{"subdir/*"}})
 	require.NoError(t, err)
 
-	out, e := sess.Run(ctx, "ls -1 /tmp/globex", &RunOpts{Verbose: true})
+	out, e := sess.Run(ctx, "ls -1 /tmp/globex", nil)
 	require.NoError(t, e)
 	assert.Contains(t, out, "keep.txt", out)
 	assert.NotContains(t, out, "subdir", "excluded directory should not be uploaded")
@@ -202,7 +202,7 @@ func TestExecuter_DownloadGlobExcludeDirectory(t *testing.T) {
 
 	// remote source with a file and a subdirectory; the glob matches both
 	_, e := sess.Run(ctx, "mkdir -p /tmp/dlex/subdir && echo keep > /tmp/dlex/keep.txt && echo inner > /tmp/dlex/subdir/inner.txt",
-		&RunOpts{Verbose: true})
+		nil)
 	require.NoError(t, e)
 
 	// excluding the matched directory must skip it instead of feeding it into sftpDownload and failing
@@ -327,7 +327,7 @@ func TestExecuter_TransferCancellation(t *testing.T) {
 
 	t.Run("canceled download preserves the existing file", func(t *testing.T) {
 		// a remote file large enough that the copy is still in flight when the (already canceled) select runs
-		_, e := sess.Run(ctx, "head -c 16777216 /dev/zero > /tmp/big.remote", &RunOpts{Verbose: true})
+		_, e := sess.Run(ctx, "head -c 16777216 /dev/zero > /tmp/big.remote", nil)
 		require.NoError(t, e)
 
 		// an existing local file with known content that a canceled overwrite must not destroy
@@ -439,7 +439,7 @@ func TestExecuter_Run(t *testing.T) {
 
 	t.Run("find out", func(t *testing.T) {
 		cmd := fmt.Sprintf("find %s -type f -exec stat -c '%%n:%%s' {} \\;", "/tmp/")
-		out, e := sess.Run(ctx, cmd, &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, cmd, nil)
 		require.NoError(t, e)
 		slices.Sort(out)
 		assert.Equal(t, []string{"/tmp/st/data1.txt:13", "/tmp/st/data2.txt:13"}, out)
@@ -460,7 +460,7 @@ func TestExecuter_Run(t *testing.T) {
 			require.NoError(t, err)
 
 			cmd := fmt.Sprintf("find %s -type f -exec stat -c '%%n:%%s' {} \\;", "/tmp/")
-			out, e := session.Run(ctx, cmd, &RunOpts{Verbose: true})
+			out, e := session.Run(ctx, cmd, nil)
 			require.NoError(t, e)
 			t.Logf("out: %v", out)
 			slices.Sort(out)
@@ -502,7 +502,7 @@ func TestExecuter_Sync(t *testing.T) {
 		require.NoError(t, e)
 		slices.Sort(res)
 		assert.Equal(t, []string{"d1/file11.txt", "file1.txt", "file2.txt"}, res)
-		out, e := sess.Run(ctx, "find /tmp/sync.dest -type f -exec stat -c '%s %n' {} \\;", &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, "find /tmp/sync.dest -type f -exec stat -c '%s %n' {} \\;", nil)
 		require.NoError(t, e)
 		slices.Sort(out)
 		assert.Equal(t, []string{"17 /tmp/sync.dest/d1/file11.txt", "185 /tmp/sync.dest/file1.txt", "61 /tmp/sync.dest/file2.txt"}, out)
@@ -519,43 +519,43 @@ func TestExecuter_Sync(t *testing.T) {
 	})
 
 	t.Run("sync with empty dir on remote to delete", func(t *testing.T) {
-		_, e := sess.Run(ctx, "mkdir -p /tmp/sync.dest2/empty", &RunOpts{Verbose: true})
+		_, e := sess.Run(ctx, "mkdir -p /tmp/sync.dest2/empty", nil)
 		require.NoError(t, e)
 		res, e := sess.Sync(ctx, "testdata/sync", "/tmp/sync.dest2", &SyncOpts{Delete: true})
 		require.NoError(t, e)
 		slices.Sort(res)
 		assert.Equal(t, []string{"d1/file11.txt", "file1.txt", "file2.txt"}, res)
-		out, e := sess.Run(ctx, "find /tmp/sync.dest2 -type f -exec stat -c '%s %n' {} \\;", &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, "find /tmp/sync.dest2 -type f -exec stat -c '%s %n' {} \\;", nil)
 		require.NoError(t, e)
 		slices.Sort(out)
 		assert.Equal(t, []string{"17 /tmp/sync.dest2/d1/file11.txt", "185 /tmp/sync.dest2/file1.txt", "61 /tmp/sync.dest2/file2.txt"}, out)
 	})
 
 	t.Run("sync with non-empty dir on remote to delete", func(t *testing.T) {
-		_, e := sess.Run(ctx, "mkdir -p /tmp/sync.dest3/empty", &RunOpts{Verbose: true})
+		_, e := sess.Run(ctx, "mkdir -p /tmp/sync.dest3/empty", nil)
 		require.NoError(t, e)
-		_, e = sess.Run(ctx, "touch /tmp/sync.dest3/empty/afile1.txt", &RunOpts{Verbose: true})
+		_, e = sess.Run(ctx, "touch /tmp/sync.dest3/empty/afile1.txt", nil)
 		require.NoError(t, e)
 		res, e := sess.Sync(ctx, "testdata/sync", "/tmp/sync.dest3", &SyncOpts{Delete: true})
 		require.NoError(t, e)
 		slices.Sort(res)
 		assert.Equal(t, []string{"d1/file11.txt", "file1.txt", "file2.txt"}, res)
-		out, e := sess.Run(ctx, "find /tmp/sync.dest3 -type f -exec stat -c '%s %n' {} \\;", &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, "find /tmp/sync.dest3 -type f -exec stat -c '%s %n' {} \\;", nil)
 		require.NoError(t, e)
 		slices.Sort(out)
 		assert.Equal(t, []string{"17 /tmp/sync.dest3/d1/file11.txt", "185 /tmp/sync.dest3/file1.txt", "61 /tmp/sync.dest3/file2.txt"}, out)
 	})
 
 	t.Run("sync  with non-empty dir on remote to keep", func(t *testing.T) {
-		_, e := sess.Run(ctx, "mkdir -p /tmp/sync.dest4/empty", &RunOpts{Verbose: true})
+		_, e := sess.Run(ctx, "mkdir -p /tmp/sync.dest4/empty", nil)
 		require.NoError(t, e)
-		_, e = sess.Run(ctx, "touch /tmp/sync.dest4/empty/afile1.txt", &RunOpts{Verbose: true})
+		_, e = sess.Run(ctx, "touch /tmp/sync.dest4/empty/afile1.txt", nil)
 		require.NoError(t, e)
 		res, e := sess.Sync(ctx, "testdata/sync", "/tmp/sync.dest4", nil)
 		require.NoError(t, e)
 		slices.Sort(res)
 		assert.Equal(t, []string{"d1/file11.txt", "file1.txt", "file2.txt"}, res)
-		out, e := sess.Run(ctx, "find /tmp/sync.dest4 -type f -exec stat -c '%s %n' {} \\;", &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, "find /tmp/sync.dest4 -type f -exec stat -c '%s %n' {} \\;", nil)
 		require.NoError(t, e)
 		slices.Sort(out)
 		assert.Equal(t, []string{"0 /tmp/sync.dest4/empty/afile1.txt", "17 /tmp/sync.dest4/d1/file11.txt",
@@ -595,26 +595,26 @@ func TestExecuter_Delete(t *testing.T) {
 	t.Run("delete dir", func(t *testing.T) {
 		err = sess.Delete(ctx, "/tmp/sync.dest", &DeleteOpts{Recursive: true})
 		require.NoError(t, err)
-		out, e := sess.Run(ctx, "ls -1 /tmp/", &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, "ls -1 /tmp/", nil)
 		require.NoError(t, e)
 		assert.NotContains(t, out, "file2.txt", out)
 	})
 
 	t.Run("delete empty dir", func(t *testing.T) {
-		_, err = sess.Run(ctx, "mkdir -p /tmp/sync.dest/empty", &RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "mkdir -p /tmp/sync.dest/empty", nil)
 		require.NoError(t, err)
-		out, e := sess.Run(ctx, "ls -1 /tmp/sync.dest", &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, "ls -1 /tmp/sync.dest", nil)
 		require.NoError(t, e)
 		assert.Contains(t, out, "empty", out)
 		err = sess.Delete(ctx, "/tmp/sync.dest/empty", nil)
 		require.NoError(t, err)
-		out, e = sess.Run(ctx, "ls -1 /tmp/sync.dest", &RunOpts{Verbose: true})
+		out, e = sess.Run(ctx, "ls -1 /tmp/sync.dest", nil)
 		require.NoError(t, e)
 		assert.NotContains(t, out, "empty", out)
 	})
 
 	t.Run("delete dir recursive without exclude does not warn", func(t *testing.T) {
-		_, err = sess.Run(ctx, "mkdir -p /tmp/nowarn/sub && touch /tmp/nowarn/a /tmp/nowarn/sub/b", &RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "mkdir -p /tmp/nowarn/sub && touch /tmp/nowarn/a /tmp/nowarn/sub/b", nil)
 		require.NoError(t, err)
 
 		buff := bytes.NewBuffer(nil)
@@ -657,29 +657,29 @@ func TestExecuter_DeleteWithExclude(t *testing.T) {
 	t.Run("delete dir with excluded files", func(t *testing.T) {
 		err = sess.Delete(ctx, "/tmp/delete.dest", &DeleteOpts{Recursive: true, Exclude: []string{"file2.*", "d1/*", "d2/file21.txt"}})
 		require.NoError(t, err)
-		out, e := sess.Run(ctx, "ls -1 /tmp/", &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, "ls -1 /tmp/", nil)
 		require.NoError(t, e)
 		assert.Contains(t, out, "delete.dest", out)
 
-		out, e = sess.Run(ctx, "ls -1 /tmp/delete.dest", &RunOpts{Verbose: true})
+		out, e = sess.Run(ctx, "ls -1 /tmp/delete.dest", nil)
 		require.NoError(t, e)
 		assert.Contains(t, out, "d1", out)
 		assert.Contains(t, out, "d2", out)
 		assert.Contains(t, out, "file2.txt", out)
 		assert.NotContains(t, out, "file3.txt", out)
 
-		out, e = sess.Run(ctx, "ls -1 /tmp/delete.dest/d1", &RunOpts{Verbose: true})
+		out, e = sess.Run(ctx, "ls -1 /tmp/delete.dest/d1", nil)
 		require.NoError(t, e)
 		assert.Contains(t, out, "file12.txt", out)
 
-		out, e = sess.Run(ctx, "ls -1 /tmp/delete.dest/d2", &RunOpts{Verbose: true})
+		out, e = sess.Run(ctx, "ls -1 /tmp/delete.dest/d2", nil)
 		require.NoError(t, e)
 		assert.Contains(t, out, "file21.txt", out)
 		assert.NotContains(t, out, "file22.txt", out)
 	})
 
 	t.Run("exclude matching nothing warns and removes tree", func(t *testing.T) {
-		_, err = sess.Run(ctx, "mkdir -p /tmp/warn.dest && touch /tmp/warn.dest/a /tmp/warn.dest/b", &RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "mkdir -p /tmp/warn.dest && touch /tmp/warn.dest/a /tmp/warn.dest/b", nil)
 		require.NoError(t, err)
 
 		buff := bytes.NewBuffer(nil)
@@ -689,7 +689,7 @@ func TestExecuter_DeleteWithExclude(t *testing.T) {
 		err = sess.Delete(ctx, "/tmp/warn.dest", &DeleteOpts{Recursive: true, Exclude: []string{"no-such-file"}})
 		require.NoError(t, err)
 		assert.Contains(t, buff.String(), "no exclude pattern matched", "a non-matching exclude should warn")
-		out, e := sess.Run(ctx, "ls -1 /tmp/", &RunOpts{Verbose: true})
+		out, e := sess.Run(ctx, "ls -1 /tmp/", nil)
 		require.NoError(t, e)
 		assert.NotContains(t, out, "warn.dest", "tree should be removed when exclude matches nothing")
 	})
@@ -817,7 +817,7 @@ func Test_getRemoteFilesProperties(t *testing.T) {
 	defer sess.Close()
 
 	// create some test data on the remote host.
-	_, err = sess.Run(ctx, "mkdir -p /tmp/testdata/dir1 /tmp/testdata/dir2 && echo 'Hello' > /tmp/testdata/dir1/file1.txt && echo 'World' > /tmp/testdata/dir2/file2.txt", &RunOpts{Verbose: true})
+	_, err = sess.Run(ctx, "mkdir -p /tmp/testdata/dir1 /tmp/testdata/dir2 && echo 'Hello' > /tmp/testdata/dir1/file1.txt && echo 'World' > /tmp/testdata/dir2/file2.txt", nil)
 	require.NoError(t, err)
 
 	props, err := sess.getRemoteFilesProperties(ctx, "/tmp/testdata", nil)

--- a/pkg/runner/commands.go
+++ b/pkg/runner/commands.go
@@ -21,6 +21,18 @@ import (
 	"github.com/umputun/spot/pkg/executor"
 )
 
+// setVarPrefix marks a line the script emits to hand a variable back to the runner.
+const setVarPrefix = "setvar "
+
+// isSetVarLine reports whether a script output line carries such a variable. It is both the
+// executor's line filter and the parse loop's guard, so the two cannot drift apart.
+func isSetVarLine(line string) bool { return strings.HasPrefix(line, setVarPrefix) }
+
+// discardOutput is the run options for call sites that ignore the returned lines. Output still
+// reaches the log in full; nothing is retained, so a command printing a large log costs no memory.
+// Safe to share: the predicate is pure and the value is never mutated.
+var discardOutput = &executor.RunOpts{KeepLine: func(string) bool { return false }}
+
 // execCmd is a single command execution on a target host. It prepares the command, executes it and returns details.
 // All commands directly correspond to the config.Cmd commands.
 type execCmd struct {
@@ -115,7 +127,7 @@ func (ec *execCmd) Script(ctx context.Context) (resp execCmdResp, err error) {
 	}
 	resp.verbose = scr
 
-	out, err := ec.exec.Run(ctx, c, &executor.RunOpts{Verbose: ec.verbose})
+	out, err := ec.exec.Run(ctx, c, &executor.RunOpts{KeepLine: isSetVarLine})
 	if err != nil {
 		return resp, ec.errorFmt("can't run script on %s: %w", ec.hostAddr, err)
 	}
@@ -126,11 +138,11 @@ func (ec *execCmd) Script(ctx context.Context) (resp execCmdResp, err error) {
 	resp.vars = make(map[string]string)       // all variables set by the script, used for the next commands in the same task
 	resp.registered = make(map[string]string) // only variables that are registered used for the next tasks too
 	for _, line := range out {
-		if !strings.HasPrefix(line, "setvar ") {
+		if !isSetVarLine(line) { // the executor already filtered, this keeps the loop correct on its own
 			continue
 		}
 		// parse format: key=value or key:SQ=value for single-quoted values
-		trimmed := strings.TrimPrefix(line, "setvar ")
+		trimmed := strings.TrimPrefix(line, setVarPrefix)
 		parts := strings.SplitN(trimmed, "=", 2)
 		if len(parts) != 2 {
 			continue
@@ -218,7 +230,7 @@ func (ec *execCmd) copyPush(ctx context.Context, src, dst string) (resp execCmdR
 			return resp, ec.errorFmt("can't copy file to %s: %w", ec.hostAddr, err)
 		}
 		if ec.cmd.Copy.ChmodX {
-			if _, err := ec.exec.Run(ctx, fmt.Sprintf("chmod +x %s", dst), &executor.RunOpts{Verbose: ec.verbose}); err != nil {
+			if _, err := ec.exec.Run(ctx, fmt.Sprintf("chmod +x %s", dst), discardOutput); err != nil {
 				return resp, ec.errorFmt("can't chmod +x file on %s: %w", ec.hostAddr, err)
 			}
 			resp.details = fmt.Sprintf(" {copy: %s -> %s, chmod: +x}", src, dst)
@@ -260,13 +272,13 @@ func (ec *execCmd) copyPush(ctx context.Context, src, dst string) (resp execCmdR
 	// run move command with sudo
 	for line := range strings.SplitSeq(c, "\n") {
 		sudoMove := ec.wrapWithSudo(line)
-		if _, err := ec.exec.Run(ctx, sudoMove, &executor.RunOpts{Verbose: ec.verbose}); err != nil {
+		if _, err := ec.exec.Run(ctx, sudoMove, discardOutput); err != nil {
 			return resp, ec.errorFmt("can't move file to %s: %w", ec.hostAddr, err)
 		}
 	}
 	if ec.cmd.Copy.ChmodX {
 		chmodCmd := ec.wrapWithSudo(fmt.Sprintf("chmod +x %s", dst))
-		if _, err := ec.exec.Run(ctx, chmodCmd, &executor.RunOpts{Verbose: ec.verbose}); err != nil {
+		if _, err := ec.exec.Run(ctx, chmodCmd, discardOutput); err != nil {
 			return resp, ec.errorFmt("can't chmod +x file on %s: %w", ec.hostAddr, err)
 		}
 		resp.details = fmt.Sprintf(" {copy: %s -> %s, sudo: true, chmod: +x}", src, dst)
@@ -322,14 +334,14 @@ func (ec *execCmd) copyPull(ctx context.Context, src, dst string) (resp execCmdR
 
 	// run copy with sudo on remote - this wraps the entire command sequence
 	sudoCmd := ec.wrapWithSudo(fmt.Sprintf("%s -c %q", ec.shell(), cpCmd))
-	if _, err := ec.exec.Run(ctx, sudoCmd, &executor.RunOpts{Verbose: ec.verbose}); err != nil {
+	if _, err := ec.exec.Run(ctx, sudoCmd, discardOutput); err != nil {
 		return resp, ec.errorFmt("can't prepare file for download with sudo on %s: %w", ec.hostAddr, err)
 	}
 
 	// cleanup function to remove temp directory on remote
 	defer func() {
 		cleanCmd := ec.wrapWithSudo(fmt.Sprintf("rm -rf %q", tmpRemoteDir))
-		if _, e := ec.exec.Run(ctx, cleanCmd, &executor.RunOpts{Verbose: false}); e != nil {
+		if _, e := ec.exec.Run(ctx, cleanCmd, discardOutput); e != nil {
 			log.Printf("[WARN] can't remove temporary directory %q on %s: %v", tmpRemoteDir, ec.hostAddr, e)
 		}
 	}()
@@ -443,7 +455,7 @@ func (ec *execCmd) Delete(ctx context.Context) (resp execCmdResp, err error) {
 			cmd = fmt.Sprintf("rm -rf %s", loc)
 		}
 		cmd = ec.wrapWithSudo(cmd)
-		if _, err := ec.exec.Run(ctx, cmd, &executor.RunOpts{Verbose: ec.verbose}); err != nil {
+		if _, err := ec.exec.Run(ctx, cmd, discardOutput); err != nil {
 			return resp, ec.errorFmt("can't delete file(s) on %s: %w", ec.hostAddr, err)
 		}
 		resp.details = fmt.Sprintf(" {delete: %s, recursive: %v, sudo: true}", loc, ec.cmd.Delete.Recursive)
@@ -528,7 +540,7 @@ func (ec *execCmd) Wait(ctx context.Context) (resp execCmdResp, err error) {
 		case <-timeoutTk.C:
 			return resp, ec.errorFmt("timeout exceeded")
 		case <-checkTk.C:
-			if _, err := ec.exec.Run(ctx, waitCmd, nil); err == nil {
+			if _, err := ec.exec.Run(ctx, waitCmd, discardOutput); err == nil {
 				return resp, nil // command succeeded
 			}
 		}
@@ -557,17 +569,14 @@ func (ec *execCmd) Echo(ctx context.Context) (resp execCmdResp, err error) {
 	if ec.cmd.Options.Sudo {
 		echoCmd = ec.wrapWithSudo(fmt.Sprintf("%s -c '%s'", ec.shell(), echoCmd))
 	}
-	out, err := ec.exec.Run(ctx, echoCmd, nil)
+	// empty lines carry nothing for the report and would show up as empty segments, so they are
+	// dropped before the executor retains them
+	keepPrinted := func(line string) bool { return line != "" }
+	out, err := ec.exec.Run(ctx, echoCmd, &executor.RunOpts{KeepLine: keepPrinted})
 	if err != nil {
 		return resp, ec.errorFmt("can't run echo command on %s: %w", ec.hostAddr, err)
 	}
-	printed := make([]string, 0, len(out))
-	for _, line := range out { // empty lines carry nothing for the report and would show up as empty segments
-		if line != "" {
-			printed = append(printed, line)
-		}
-	}
-	resp.details = fmt.Sprintf(" {echo: %s}", strings.Join(printed, "; "))
+	resp.details = fmt.Sprintf(" {echo: %s}", strings.Join(out, "; "))
 	return resp, nil
 }
 
@@ -620,7 +629,7 @@ func (ec *execCmd) Line(ctx context.Context) (resp execCmdResp, err error) {
 		// first check if the pattern exists in the file
 		checkCmd := fmt.Sprintf("grep -q '%s' %s", match, file)
 		checkCmd = ec.wrapWithSudo(checkCmd)
-		if _, err := ec.exec.Run(ctx, checkCmd, &executor.RunOpts{Verbose: ec.verbose}); err != nil {
+		if _, err := ec.exec.Run(ctx, checkCmd, discardOutput); err != nil {
 			// pattern not found, append the line using tee -a for proper sudo support
 			if ec.cmd.Options.Sudo {
 				operationCmd = fmt.Sprintf("echo '%s' | sudo tee -a %s > /dev/null", appendLine, file)
@@ -643,7 +652,7 @@ func (ec *execCmd) Line(ctx context.Context) (resp execCmdResp, err error) {
 	}
 
 	// execute the operation
-	_, err = ec.exec.Run(ctx, operationCmd, &executor.RunOpts{Verbose: ec.verbose})
+	_, err = ec.exec.Run(ctx, operationCmd, discardOutput)
 	if err != nil {
 		return resp, ec.errorFmt("can't execute line %s on %s: %w", operation, ec.hostAddr, err)
 	}
@@ -676,7 +685,7 @@ func (ec *execCmd) checkCondition(ctx context.Context) (bool, error) {
 	}
 
 	// run the condition command
-	if _, err := ec.exec.Run(ctx, c, &executor.RunOpts{Verbose: ec.verbose}); err != nil {
+	if _, err := ec.exec.Run(ctx, c, discardOutput); err != nil {
 		log.Printf("[DEBUG] condition not passed on %s: %v", ec.hostAddr, err)
 		if inverted {
 			return true, nil // inverted condition failed, so we return true

--- a/pkg/runner/commands_test.go
+++ b/pkg/runner/commands_test.go
@@ -471,7 +471,7 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("delete a single file", func(t *testing.T) {
-		_, err := sess.Run(ctx, "touch /tmp/delete.me", &executor.RunOpts{Verbose: true})
+		_, err := sess.Run(ctx, "touch /tmp/delete.me", nil)
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
 			Location: "/tmp/delete.me"}}}
@@ -480,27 +480,27 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("delete a multi-files", func(t *testing.T) {
-		_, err := sess.Run(ctx, "touch /tmp/delete1.me /tmp/delete2.me ", &executor.RunOpts{Verbose: true})
+		_, err := sess.Run(ctx, "touch /tmp/delete1.me /tmp/delete2.me ", nil)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "ls /tmp/delete1.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/delete1.me", nil)
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{MDelete: []config.DeleteInternal{
 			{Location: "/tmp/delete1.me"}, {Location: "/tmp/delete2.me"}}}}
 		_, err = ec.MDelete(ctx)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "ls /tmp/delete1.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/delete1.me", nil)
 		require.Error(t, err)
-		_, err = sess.Run(ctx, "ls /tmp/delete2.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/delete2.me", nil)
 		require.Error(t, err)
 	})
 
 	t.Run("delete files recursive", func(t *testing.T) {
 		var err error
-		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-recursive", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-recursive", nil)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "touch /tmp/delete-recursive/delete1.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "touch /tmp/delete-recursive/delete1.me", nil)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "touch /tmp/delete-recursive/delete2.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "touch /tmp/delete-recursive/delete2.me", nil)
 		require.NoError(t, err)
 
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
@@ -509,15 +509,15 @@ func Test_execCmd(t *testing.T) {
 		_, err = ec.Delete(ctx)
 		require.NoError(t, err)
 
-		_, err = sess.Run(ctx, "ls /tmp/delete-recursive", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/delete-recursive", nil)
 		require.Error(t, err, "should not exist")
 	})
 
 	t.Run("delete files recursive with exclude", func(t *testing.T) {
 		var err error
-		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-exclude/keep", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-exclude/keep", nil)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "touch /tmp/delete-exclude/delete1.me /tmp/delete-exclude/keep/keep.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "touch /tmp/delete-exclude/delete1.me /tmp/delete-exclude/keep/keep.me", nil)
 		require.NoError(t, err)
 
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
@@ -526,9 +526,9 @@ func Test_execCmd(t *testing.T) {
 		_, err = ec.Delete(ctx)
 		require.NoError(t, err)
 
-		_, err = sess.Run(ctx, "ls /tmp/delete-exclude/delete1.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/delete-exclude/delete1.me", nil)
 		require.Error(t, err, "should be deleted")
-		_, err = sess.Run(ctx, "ls /tmp/delete-exclude/keep/keep.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/delete-exclude/keep/keep.me", nil)
 		require.NoError(t, err, "excluded file should survive")
 	})
 
@@ -542,24 +542,24 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("delete with exclude without recur rejected", func(t *testing.T) {
-		_, err := sess.Run(ctx, "mkdir -p /tmp/delete-norecur", &executor.RunOpts{Verbose: true})
+		_, err := sess.Run(ctx, "mkdir -p /tmp/delete-norecur", nil)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "touch /tmp/delete-norecur/keep.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "touch /tmp/delete-norecur/keep.me", nil)
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
 			Location: "/tmp/delete-norecur", Exclude: []string{"keep.me"}}}}
 		_, err = ec.Delete(ctx)
 		require.ErrorContains(t, err, "requires recursive")
 		require.ErrorContains(t, err, "/tmp/delete-norecur", "error should name the offending location")
-		_, err = sess.Run(ctx, "ls /tmp/delete-norecur/keep.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/delete-norecur/keep.me", nil)
 		require.NoError(t, err, "nothing should be deleted when validation fails")
 	})
 
 	t.Run("delete files recursive with non-matching nested exclude", func(t *testing.T) {
 		var err error
-		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-exclude2/logs/archive", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "mkdir -p /tmp/delete-exclude2/logs/archive", nil)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "touch /tmp/delete-exclude2/logs/archive/drop.log", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "touch /tmp/delete-exclude2/logs/archive/drop.log", nil)
 		require.NoError(t, err)
 
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
@@ -568,12 +568,12 @@ func Test_execCmd(t *testing.T) {
 		_, err = ec.Delete(ctx)
 		require.NoError(t, err)
 
-		_, err = sess.Run(ctx, "ls /tmp/delete-exclude2", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/delete-exclude2", nil)
 		require.Error(t, err, "directory should be fully removed when exclusion matches nothing")
 	})
 
 	t.Run("mdelete with exclude and sudo rejected before deleting", func(t *testing.T) {
-		_, err := sess.Run(ctx, "touch /tmp/mdelete-first.me", &executor.RunOpts{Verbose: true})
+		_, err := sess.Run(ctx, "touch /tmp/mdelete-first.me", nil)
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{MDelete: []config.DeleteInternal{
 			{Location: "/tmp/mdelete-first.me"}, {Location: "/tmp/whatever", Recursive: true, Exclude: []string{"keep.me"}}},
@@ -581,12 +581,12 @@ func Test_execCmd(t *testing.T) {
 		_, err = ec.MDelete(ctx)
 		require.ErrorContains(t, err, "not supported with sudo")
 		require.ErrorContains(t, err, "/tmp/whatever", "error should name the offending location")
-		_, err = sess.Run(ctx, "ls /tmp/mdelete-first.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /tmp/mdelete-first.me", nil)
 		require.NoError(t, err, "first location should not be deleted")
 	})
 
 	t.Run("delete file with sudo", func(t *testing.T) {
-		_, err := sess.Run(ctx, "sudo touch /srv/delete.me", &executor.RunOpts{Verbose: true})
+		_, err := sess.Run(ctx, "sudo touch /srv/delete.me", nil)
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
 			Location: "/srv/delete.me"}, Options: config.CmdOptions{Sudo: false}}}
@@ -603,11 +603,11 @@ func Test_execCmd(t *testing.T) {
 
 	t.Run("delete files recursive with sudo", func(t *testing.T) {
 		var err error
-		_, err = sess.Run(ctx, "sudo mkdir -p /srv/delete-recursive", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "sudo mkdir -p /srv/delete-recursive", nil)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "sudo touch /srv/delete-recursive/delete1.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "sudo touch /srv/delete-recursive/delete1.me", nil)
 		require.NoError(t, err)
-		_, err = sess.Run(ctx, "sudo touch /srv/delete-recursive/delete2.me", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "sudo touch /srv/delete-recursive/delete2.me", nil)
 		require.NoError(t, err)
 
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Delete: config.DeleteInternal{
@@ -616,7 +616,7 @@ func Test_execCmd(t *testing.T) {
 		_, err = ec.Delete(ctx)
 		require.NoError(t, err)
 
-		_, err = sess.Run(ctx, "ls /srv/delete-recursive", &executor.RunOpts{Verbose: true})
+		_, err = sess.Run(ctx, "ls /srv/delete-recursive", nil)
 		require.Error(t, err, "should not exist")
 	})
 
@@ -629,7 +629,7 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("condition true", func(t *testing.T) {
-		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", &executor.RunOpts{Verbose: true})
+		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", nil)
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Condition: "ls -la /srv/test.condition",
 			Script: "echo condition true", Name: "test"}}
@@ -655,7 +655,7 @@ func Test_execCmd(t *testing.T) {
 	})
 
 	t.Run("condition true inverted", func(t *testing.T) {
-		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", &executor.RunOpts{Verbose: true})
+		_, err := sess.Run(ctx, "sudo touch /srv/test.condition", nil)
 		require.NoError(t, err)
 		ec := execCmd{exec: sess, tsk: &config.Task{Name: "test"}, cmd: config.Cmd{Condition: "! ls -la /srv/test.condition",
 			Script: "echo condition true", Name: "test"}}


### PR DESCRIPTION
Previously, `Local.Run` and `Remote.sshRun` streamed stdout to the log and at the same time retained every byte in a `bytes.Buffer`, then handed the whole buffer to `splitOutputLines`, which copied it again. A command printing a large log therefore cost roughly two copies of its output, including at the ten call sites that discard the result.

After this change, `RunOpts` carries `KeepLine func(line string) bool`, a predicate deciding which lines `Run` returns; a nil predicate keeps every line. Every line still reaches the log in full, so this bounds only what the caller retains. `Script` passes the same `setvar ` test its parse loop uses, so the two cannot drift; `Echo` keeps the non-empty lines it reports; the sites that ignore the result share a `discardOutput` value.

The capture is now a streaming writer in place of the buffer, so output is never fully retained. It reproduces the previous `splitOutputLines(buffer.String())` exactly, which the tests pin across five write chunk sizes so that a line split across writes, a `\r\n` pair split down the middle and a run of newlines all give the same answer as the batch split. A line of any length still arrives whole, and an unterminated final line is returned like a terminated one.

Measured with the reproduction from #363, three runs each:

| | peak RSS |
| --- | --- |
| before | 215.9, 216.0, 217.3 MB |
| after | 27.8, 28.0, 27.2 MB |

The issue's control run, with the same output sent to `/dev/null`, sat at 21.5 to 22.4 MB.

`Verbose` is dropped from `RunOpts`, dead since 6c872a3a: all three executors took it as `_` and verbosity comes from `MakeLogs`. As noted in the issue, `KeepLine` makes `RunOpts` non-comparable, which nothing in the tree depends on.

A line spanning several writes has to be staged, and the staging buffer is released once it grows past 64KiB rather than being kept for reuse. Holding it would pin the longest line for the rest of the command, which is the retention this change removes elsewhere.

The last commit is the `maskSecrets` point raised at the end of the issue: it compiled a regexp per secret on every call, and it is called for every line of every command. Patterns are now compiled once in `MakeLogs` and shared by every writer. On a typical log line with four secrets configured, masking drops from 6031 to 2190 ns/op. It sits on its own commit and can be split out if you would rather keep it separate.

Resolves #363.
