### PR TITLE
fix: mask secrets in prefixless logs and Printf

### DIFF
--- a/pkg/executor/logger.go
+++ b/pkg/executor/logger.go
@@ -88,11 +88,11 @@ func (s *colorizedWriter) Write(p []byte) (n int, err error) {
 			hostID = s.hostName + " " + s.hostAddr
 		}
 		formattedOutput := fmt.Sprintf("[%s] %s %s", hostID, s.prefix, line)
-		formattedOutput = s.masker.mask(formattedOutput)
-
 		if s.prefix == "" {
 			formattedOutput = fmt.Sprintf("[%s] %s", hostID, line)
 		}
+		// mask after choosing the format so an empty prefix cannot discard masking
+		formattedOutput = s.masker.mask(formattedOutput)
 		colorizer := s.hostColorizer(s.hostAddr)
 		colorizedOutput := colorizer("%s\n", formattedOutput)
 		_, err = io.WriteString(s.wr, colorizedOutput)
@@ -210,7 +210,7 @@ func (w *stdOutLogWriter) Write(p []byte) (n int, err error) {
 
 // Printf writes the given text to log with the prefix and log level.
 func (w *stdOutLogWriter) Printf(format string, v ...any) {
-	log.Printf("[%s] %s %s", w.level, w.prefix, fmt.Sprintf(format, v...))
+	log.Printf("[%s] %s %s", w.level, w.prefix, w.masker.mask(fmt.Sprintf(format, v...)))
 }
 
 // WithHost does nothing for stdOutLogWriter.

--- a/pkg/executor/logger_test.go
+++ b/pkg/executor/logger_test.go
@@ -395,3 +395,33 @@ func TestColorizedWriter_LineOverScannerLimit(t *testing.T) {
 	assert.Equal(t, len(line)+1, n)
 	assert.Contains(t, buf.String(), line)
 }
+
+func TestColorizedWriter_WriteWithoutPrefixMasksSecrets(t *testing.T) {
+	// an empty prefix must not discard masking of the line or host label
+	var buf bytes.Buffer
+	w := &colorizedWriter{wr: &buf, prefix: "", hostAddr: "localhost",
+		masker: newSecretsMasker([]string{"token321"})}
+	_, err := w.Write([]byte("deploying with token321\n"))
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "token321")
+	assert.Contains(t, buf.String(), "****")
+
+	buf.Reset()
+	w = &colorizedWriter{wr: &buf, prefix: "", hostAddr: "token321",
+		masker: newSecretsMasker([]string{"token321"})}
+	w.Printf("deploying")
+	assert.NotContains(t, buf.String(), "token321", "a secret matching the host label is masked too")
+}
+
+func TestStdOutLogWriter_PrintfMasksSecrets(t *testing.T) {
+	var buf bytes.Buffer
+	wr, flags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() { log.SetOutput(wr); log.SetFlags(flags) }()
+
+	w := &stdOutLogWriter{prefix: " >", level: "DEBUG", masker: newSecretsMasker([]string{"token321"})}
+	w.Printf("deploying with %s", "token321")
+	assert.NotContains(t, buf.String(), "token321")
+	assert.Contains(t, buf.String(), "****")
+}


### PR DESCRIPTION
two paths in `pkg/executor/logger.go` wrote a configured secret to the log unmasked. Based on the patch supplied by @paskal in #368.

`colorizedWriter.Write` masked the formatted line and then rebuilt it from the raw line when the prefix was empty, throwing the masked copy away. `MakeLogs` gives only `Info` an empty prefix, so its host label skipped masking entirely. That label now goes through the existing masking rules, since masking runs after the format is chosen.

`stdOutLogWriter.Printf` never masked at all. This can expose secrets when a caller of the package uses `Out.Printf` or `Err.Printf`; spot itself does not call either.

both regression tests fail with their own fix reverted.

Related to #368
